### PR TITLE
Separate version bumping from publishing workflows

### DIFF
--- a/.github/workflows/bump-bebytes.yml
+++ b/.github/workflows/bump-bebytes.yml
@@ -44,8 +44,6 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
 
-      - name: Bump version
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
-        run: cargo release -v --execute --no-confirm ${{ steps.extract_version.outputs.version_component }}
+      - name: Bump version only (no publishing)
+        run: cargo release version -v --execute --no-confirm ${{ steps.extract_version.outputs.version_component }}
         working-directory: bebytes

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,20 +1,19 @@
-name: Bump Version bebytes_derive
+name: Publish Crates to crates.io
 
 on:
   workflow_dispatch:
     inputs:
-      version_component:
-        description: 'Version component to bump (major, minor, patch)'
+      crate:
+        description: 'Crate to publish'
         required: true
-        default: 'patch'
         type: choice
         options:
-          - major
-          - minor
-          - patch
+          - bebytes
+          - bebytes_derive
+          - all
 
 jobs:
-  bump_version:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,11 +22,6 @@ jobs:
         with:
           token: ${{ secrets.PA_TOKEN }}
           fetch-depth: 0
-
-      - name: Set version component
-        id: extract_version
-        run: |
-          echo "::set-output name=version_component::${{ github.event.inputs.version_component }}"
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -44,6 +38,16 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "actions@github.com"
 
-      - name: Bump version only (no publishing)
-        run: cargo release version -v --execute --no-confirm ${{ steps.extract_version.outputs.version_component }}
+      - name: Publish bebytes_derive
+        if: github.event.inputs.crate == 'bebytes_derive' || github.event.inputs.crate == 'all'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
+        run: cargo release publish -v --execute --no-confirm
         working-directory: bebytes_derive
+
+      - name: Publish bebytes
+        if: github.event.inputs.crate == 'bebytes' || github.event.inputs.crate == 'all'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
+        run: cargo release publish -v --execute --no-confirm
+        working-directory: bebytes


### PR DESCRIPTION
This PR separates the version bumping process from the publishing workflow, allowing more control over the release process.

## Changes

- Updates bump-bebytes and bump-bebytes-derive workflows to only bump versions using cargo release version
- Adds a new publish-crates workflow for manual publishing to crates.io
- Allows publishing specific crates or all at once through a dropdown menu