### PR TITLE
minor: Add little-endian support to BeBytes

### DIFF
--- a/bebytes/bin/macro_test.rs
+++ b/bebytes/bin/macro_test.rs
@@ -5,7 +5,7 @@ use bebytes::BeBytes;
 fn main() {
     // Test both endianness formats
     test_both_endianness();
-    
+
     let client_setup_response = ArrayedStruct::new(Modes::new(0), [1; 1], [2; 2], [3; 3]);
     let bytes = client_setup_response.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
@@ -221,63 +221,69 @@ fn main() {
 // Test that both endianness formats work correctly
 fn test_both_endianness() {
     println!("\n=== TESTING BOTH ENDIANNESS FORMATS ===\n");
-    
-    // Test with a simple struct 
+
+    // Test with a simple struct
     let test_struct = U16 {
         first: 1,
         second: 16383,
         fourth: 0,
     };
-    
+
     // Convert to big-endian
     let be_bytes = test_struct.to_be_bytes();
     println!("Big-endian bytes: {:?}", be_bytes);
-    
+
     // Convert to little-endian
     let le_bytes = test_struct.to_le_bytes();
     println!("Little-endian bytes: {:?}", le_bytes);
-    
+
     // They should be different
-    assert_ne!(be_bytes, le_bytes, "Big-endian and little-endian representations should differ");
-    
+    assert_ne!(
+        be_bytes, le_bytes,
+        "Big-endian and little-endian representations should differ"
+    );
+
     // Parse from big-endian
     let (from_be, be_len) = U16::try_from_be_bytes(&be_bytes).unwrap();
     println!("Parsed from BE: {:?}, len: {}", from_be, be_len);
     assert_eq!(test_struct, from_be);
-    
+
     // Parse from little-endian
     let (from_le, le_len) = U16::try_from_le_bytes(&le_bytes).unwrap();
     println!("Parsed from LE: {:?}, len: {}", from_le, le_len);
     assert_eq!(test_struct, from_le);
-    
+
     // Parsing big-endian as little-endian should yield incorrect results
     if let Ok((wrong_endian, _)) = U16::try_from_le_bytes(&be_bytes) {
-        assert_ne!(test_struct, wrong_endian, "Parsing BE bytes as LE should give different results");
+        assert_ne!(
+            test_struct, wrong_endian,
+            "Parsing BE bytes as LE should give different results"
+        );
         println!("BE bytes parsed as LE (incorrectly): {:?}", wrong_endian);
     }
-    
+
     // Test with a medium complexity struct (U32)
     let test_u32 = U32 {
         first: 1,
         second: 32383,
         fourth: 1,
     };
-    
+
     // Test big-endian serialization and deserialization
     let u32_be = test_u32.to_be_bytes();
     println!("U32 BE bytes: {:?}", u32_be);
     let (parsed_u32_be, _) = U32::try_from_be_bytes(&u32_be).unwrap();
     assert_eq!(test_u32, parsed_u32_be);
-    
+
     // Test little-endian serialization and deserialization
     let u32_le = test_u32.to_le_bytes();
     println!("U32 LE bytes: {:?}", u32_le);
     let (parsed_u32_le, _) = U32::try_from_le_bytes(&u32_le).unwrap();
     assert_eq!(test_u32, parsed_u32_le);
-    
+
     // They should be different representations
     assert_ne!(u32_be, u32_le);
-    
+
     println!("Both endianness formats work correctly!\n");
 }
 

--- a/bebytes/bin/macro_test.rs
+++ b/bebytes/bin/macro_test.rs
@@ -3,6 +3,9 @@
 use bebytes::BeBytes;
 
 fn main() {
+    // Test both endianness formats
+    test_both_endianness();
+    
     let client_setup_response = ArrayedStruct::new(Modes::new(0), [1; 1], [2; 2], [3; 3]);
     let bytes = client_setup_response.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
@@ -213,6 +216,69 @@ fn main() {
     let re_i_8 = I8::try_from_be_bytes(&i_8_bytes);
     println!("{:?}", re_i_8);
     assert_eq!(i_8, re_i_8.unwrap().0);
+}
+
+// Test that both endianness formats work correctly
+fn test_both_endianness() {
+    println!("\n=== TESTING BOTH ENDIANNESS FORMATS ===\n");
+    
+    // Test with a simple struct 
+    let test_struct = U16 {
+        first: 1,
+        second: 16383,
+        fourth: 0,
+    };
+    
+    // Convert to big-endian
+    let be_bytes = test_struct.to_be_bytes();
+    println!("Big-endian bytes: {:?}", be_bytes);
+    
+    // Convert to little-endian
+    let le_bytes = test_struct.to_le_bytes();
+    println!("Little-endian bytes: {:?}", le_bytes);
+    
+    // They should be different
+    assert_ne!(be_bytes, le_bytes, "Big-endian and little-endian representations should differ");
+    
+    // Parse from big-endian
+    let (from_be, be_len) = U16::try_from_be_bytes(&be_bytes).unwrap();
+    println!("Parsed from BE: {:?}, len: {}", from_be, be_len);
+    assert_eq!(test_struct, from_be);
+    
+    // Parse from little-endian
+    let (from_le, le_len) = U16::try_from_le_bytes(&le_bytes).unwrap();
+    println!("Parsed from LE: {:?}, len: {}", from_le, le_len);
+    assert_eq!(test_struct, from_le);
+    
+    // Parsing big-endian as little-endian should yield incorrect results
+    if let Ok((wrong_endian, _)) = U16::try_from_le_bytes(&be_bytes) {
+        assert_ne!(test_struct, wrong_endian, "Parsing BE bytes as LE should give different results");
+        println!("BE bytes parsed as LE (incorrectly): {:?}", wrong_endian);
+    }
+    
+    // Test with a medium complexity struct (U32)
+    let test_u32 = U32 {
+        first: 1,
+        second: 32383,
+        fourth: 1,
+    };
+    
+    // Test big-endian serialization and deserialization
+    let u32_be = test_u32.to_be_bytes();
+    println!("U32 BE bytes: {:?}", u32_be);
+    let (parsed_u32_be, _) = U32::try_from_be_bytes(&u32_be).unwrap();
+    assert_eq!(test_u32, parsed_u32_be);
+    
+    // Test little-endian serialization and deserialization
+    let u32_le = test_u32.to_le_bytes();
+    println!("U32 LE bytes: {:?}", u32_le);
+    let (parsed_u32_le, _) = U32::try_from_le_bytes(&u32_le).unwrap();
+    assert_eq!(test_u32, parsed_u32_le);
+    
+    // They should be different representations
+    assert_ne!(u32_be, u32_le);
+    
+    println!("Both endianness formats work correctly!\n");
 }
 
 #[derive(BeBytes, Debug, PartialEq)]

--- a/bebytes/src/lib.rs
+++ b/bebytes/src/lib.rs
@@ -15,6 +15,7 @@ pub use bebytes_derive::BeBytes;
 pub trait BeBytes {
     fn field_size() -> usize;
 
+    // Big-endian methods
     #[cfg(feature = "std")]
     fn to_be_bytes(&self) -> std::vec::Vec<u8>;
 
@@ -30,6 +31,25 @@ pub trait BeBytes {
 
     #[cfg(not(feature = "std"))]
     fn try_from_be_bytes(bytes: &'_ [u8]) -> core::result::Result<(Self, usize), Infallible>
+    where
+        Self: Sized;
+        
+    // Little-endian methods
+    #[cfg(feature = "std")]
+    fn to_le_bytes(&self) -> std::vec::Vec<u8>;
+
+    #[cfg(not(feature = "std"))]
+    fn to_le_bytes(&self) -> alloc::vec::Vec<u8>;
+
+    #[cfg(feature = "std")]
+    fn try_from_le_bytes(
+        bytes: &'_ [u8],
+    ) -> core::result::Result<(Self, usize), std::boxed::Box<dyn std::error::Error>>
+    where
+        Self: Sized;
+
+    #[cfg(not(feature = "std"))]
+    fn try_from_le_bytes(bytes: &'_ [u8]) -> core::result::Result<(Self, usize), Infallible>
     where
         Self: Sized;
 }

--- a/bebytes/src/lib.rs
+++ b/bebytes/src/lib.rs
@@ -33,7 +33,7 @@ pub trait BeBytes {
     fn try_from_be_bytes(bytes: &'_ [u8]) -> core::result::Result<(Self, usize), Infallible>
     where
         Self: Sized;
-        
+
     // Little-endian methods
     #[cfg(feature = "std")]
     fn to_le_bytes(&self) -> std::vec::Vec<u8>;

--- a/bebytes/tests/runtime_tests.rs
+++ b/bebytes/tests/runtime_tests.rs
@@ -55,23 +55,28 @@ fn test_to_le_bytes(input: ErrorEstimate, expected: Vec<u8>) {
 
 #[test]
 fn test_endian_conversion() {
-    let original = ErrorEstimate { s_bit: 1, z_bit: 0, scale: 63, multiplier: 100 };
-    
+    let original = ErrorEstimate {
+        s_bit: 1,
+        z_bit: 0,
+        scale: 63,
+        multiplier: 100,
+    };
+
     // Convert to big-endian
     let be_bytes = original.to_be_bytes();
     // Read back from big-endian
     let (from_be, _) = ErrorEstimate::try_from_be_bytes(&be_bytes).unwrap();
     assert_eq!(original, from_be);
-    
+
     // Convert to little-endian
     let le_bytes = original.to_le_bytes();
     // Read back from little-endian
     let (from_le, _) = ErrorEstimate::try_from_le_bytes(&le_bytes).unwrap();
     assert_eq!(original, from_le);
-    
+
     // Ensure the byte representations are different
     assert_ne!(be_bytes, le_bytes);
-    
+
     // But trying to read big-endian data as little-endian should give incorrect results
     let (wrong_endian, _) = ErrorEstimate::try_from_le_bytes(&be_bytes).unwrap();
     assert_ne!(original, wrong_endian);

--- a/bebytes/tests/runtime_tests.rs
+++ b/bebytes/tests/runtime_tests.rs
@@ -46,6 +46,37 @@ fn test_to_be_bytes(input: ErrorEstimate, expected: Vec<u8>) {
     assert_eq!(bytes, expected);
 }
 
+#[test_case(ErrorEstimate { s_bit: 0, z_bit: 1, scale: 0, multiplier: 1 }, vec![2, 1, 0, 0, 0]; "le_input1")]
+#[test_case(ErrorEstimate { s_bit: 1, z_bit: 0, scale: 63, multiplier: 100 }, vec![253, 100, 0, 0, 0]; "le_input2")]
+fn test_to_le_bytes(input: ErrorEstimate, expected: Vec<u8>) {
+    let bytes = input.to_le_bytes();
+    assert_eq!(bytes, expected);
+}
+
+#[test]
+fn test_endian_conversion() {
+    let original = ErrorEstimate { s_bit: 1, z_bit: 0, scale: 63, multiplier: 100 };
+    
+    // Convert to big-endian
+    let be_bytes = original.to_be_bytes();
+    // Read back from big-endian
+    let (from_be, _) = ErrorEstimate::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(original, from_be);
+    
+    // Convert to little-endian
+    let le_bytes = original.to_le_bytes();
+    // Read back from little-endian
+    let (from_le, _) = ErrorEstimate::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(original, from_le);
+    
+    // Ensure the byte representations are different
+    assert_ne!(be_bytes, le_bytes);
+    
+    // But trying to read big-endian data as little-endian should give incorrect results
+    let (wrong_endian, _) = ErrorEstimate::try_from_le_bytes(&be_bytes).unwrap();
+    assert_ne!(original, wrong_endian);
+}
+
 #[test]
 #[should_panic(expected = "Value of field scale is out of range")]
 fn test_value_out_of_range() {

--- a/bebytes_derive/src/consts.rs
+++ b/bebytes_derive/src/consts.rs
@@ -5,3 +5,9 @@ pub const PRIMITIVES: [&str; 17] = [
 pub const SUPPORTED_PRIMITIVES: [&str; 10] = [
     "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128",
 ];
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Endianness {
+    Big,
+    Little,
+}

--- a/bebytes_derive/src/enums.rs
+++ b/bebytes_derive/src/enums.rs
@@ -47,7 +47,7 @@ pub fn handle_enum(
             }
         })
         .collect::<Vec<_>>();
-    
+
     // For enums, the byte representation is the same for both endianness since we're just storing a single byte value
     (from_bytes_arms, to_bytes_arms)
 }

--- a/bebytes_derive/src/enums.rs
+++ b/bebytes_derive/src/enums.rs
@@ -30,7 +30,7 @@ pub fn handle_enum(
         })
         .collect::<Vec<_>>();
 
-    let from_be_bytes_arms = values
+    let from_bytes_arms = values
         .iter()
         .map(|(ident, assigned_value)| {
             quote! {
@@ -39,7 +39,7 @@ pub fn handle_enum(
         })
         .collect::<Vec<_>>();
 
-    let to_be_bytes_arms = values
+    let to_bytes_arms = values
         .iter()
         .map(|(ident, assigned_value)| {
             quote! {
@@ -47,5 +47,7 @@ pub fn handle_enum(
             }
         })
         .collect::<Vec<_>>();
-    (from_be_bytes_arms, to_be_bytes_arms)
+    
+    // For enums, the byte representation is the same for both endianness since we're just storing a single byte value
+    (from_bytes_arms, to_bytes_arms)
 }

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -30,15 +30,15 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
     let mut field_limit_check = Vec::new();
 
     let mut errors = Vec::new();
-    
+
     // For big-endian implementation
     let mut be_field_parsing = Vec::new();
     let mut be_field_writing = Vec::new();
-    
+
     // For little-endian implementation
     let mut le_field_parsing = Vec::new();
     let mut le_field_writing = Vec::new();
-    
+
     // Common elements
     let mut bit_sum = Vec::new();
     let mut named_fields = Vec::new();
@@ -64,7 +64,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                     last_field,
                     endianness: Endianness::Big,
                 });
-                
+
                 // Generate little-endian implementation
                 // We reuse named_fields and bit_sum because they're the same
                 let mut le_named_fields = Vec::new();
@@ -102,7 +102,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                             #(#bit_sum)*
                             bit_sum / 8
                         }
-                        
+
                         // Big-endian implementation
                         fn try_from_be_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                             if bytes.is_empty() {
@@ -128,7 +128,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                             )*
                             bytes
                         }
-                        
+
                         // Little-endian implementation
                         fn try_from_le_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                             if bytes.is_empty() {
@@ -184,7 +184,8 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
             }
         },
         Data::Enum(data_enum) => {
-            let (from_be_bytes_arms, to_be_bytes_arms) = enums::handle_enum(errors, data_enum.clone());
+            let (from_be_bytes_arms, to_be_bytes_arms) =
+                enums::handle_enum(errors, data_enum.clone());
             let (from_le_bytes_arms, to_le_bytes_arms) = enums::handle_enum(Vec::new(), data_enum);
 
             let expanded = quote! {
@@ -192,7 +193,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                     fn field_size() -> usize {
                         core::mem::size_of::<Self>()
                     }
-                    
+
                     // Big-endian implementation
                     fn try_from_be_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                         if bytes.is_empty() {
@@ -213,7 +214,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                         bytes.push(val);
                         bytes
                     }
-                    
+
                     // Little-endian implementation
                     fn try_from_le_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                         if bytes.is_empty() {

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -20,6 +20,8 @@ use std::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use consts::Endianness;
+
 #[proc_macro_derive(BeBytes, attributes(U8, With, FromField))]
 pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -28,9 +30,17 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
     let mut field_limit_check = Vec::new();
 
     let mut errors = Vec::new();
-    let mut field_parsing = Vec::new();
+    
+    // For big-endian implementation
+    let mut be_field_parsing = Vec::new();
+    let mut be_field_writing = Vec::new();
+    
+    // For little-endian implementation
+    let mut le_field_parsing = Vec::new();
+    let mut le_field_writing = Vec::new();
+    
+    // Common elements
     let mut bit_sum = Vec::new();
-    let mut field_writing = Vec::new();
     let mut named_fields = Vec::new();
 
     match input.data {
@@ -41,16 +51,34 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                 let total_size: usize = 0;
                 let last_field = fields.named.last();
 
+                // Generate big-endian implementation
                 structs::handle_struct(structs::StructContext {
                     field_limit_check: &mut field_limit_check,
                     errors: &mut errors,
-                    field_parsing: &mut field_parsing,
+                    field_parsing: &mut be_field_parsing,
                     bit_sum: &mut bit_sum,
-                    field_writing: &mut field_writing,
+                    field_writing: &mut be_field_writing,
                     named_fields: &mut named_fields,
                     fields: &fields,
                     total_size,
                     last_field,
+                    endianness: Endianness::Big,
+                });
+                
+                // Generate little-endian implementation
+                // We reuse named_fields and bit_sum because they're the same
+                let mut le_named_fields = Vec::new();
+                structs::handle_struct(structs::StructContext {
+                    field_limit_check: &mut Vec::new(), // Already generated
+                    errors: &mut errors,
+                    field_parsing: &mut le_field_parsing,
+                    bit_sum: &mut Vec::new(), // Already generated
+                    field_writing: &mut le_field_writing,
+                    named_fields: &mut le_named_fields,
+                    fields: &fields,
+                    total_size,
+                    last_field,
+                    endianness: Endianness::Little,
                 });
 
                 // If there are any errors, return them immediately without generating code
@@ -69,6 +97,13 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
 
                 let expanded = quote! {
                     impl #my_trait_path for #name {
+                        fn field_size() -> usize {
+                            let mut bit_sum = 0;
+                            #(#bit_sum)*
+                            bit_sum / 8
+                        }
+                        
+                        // Big-endian implementation
                         fn try_from_be_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                             if bytes.is_empty() {
                                 return Err("No bytes provided.".into());
@@ -78,7 +113,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                             let mut byte_index = 0;
                             let mut end_byte_index = 0;
                             let buffer_size = bytes.len();
-                            #(#field_parsing)*
+                            #(#be_field_parsing)*
                             Ok((Self {
                                 #( #struct_field_names, )*
                             }, _bit_sum / 8))
@@ -89,15 +124,35 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                             let mut _bit_sum = 0;
                             #(
                                 #named_fields
-                                #field_writing
+                                #be_field_writing
                             )*
                             bytes
                         }
+                        
+                        // Little-endian implementation
+                        fn try_from_le_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
+                            if bytes.is_empty() {
+                                return Err("No bytes provided.".into());
+                            }
 
-                        fn field_size() -> usize {
-                            let mut bit_sum = 0;
-                            #(#bit_sum)*
-                            bit_sum / 8
+                            let mut _bit_sum = 0;
+                            let mut byte_index = 0;
+                            let mut end_byte_index = 0;
+                            let buffer_size = bytes.len();
+                            #(#le_field_parsing)*
+                            Ok((Self {
+                                #( #struct_field_names, )*
+                            }, _bit_sum / 8))
+                        }
+
+                        fn to_le_bytes(&self) -> Vec<u8> {
+                            let mut bytes = Vec::with_capacity(256);
+                            let mut _bit_sum = 0;
+                            #(
+                                #le_named_fields
+                                #le_field_writing
+                            )*
+                            bytes
                         }
                     }
 
@@ -129,10 +184,16 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
             }
         },
         Data::Enum(data_enum) => {
-            let (from_be_bytes_arms, to_be_bytes_arms) = enums::handle_enum(errors, data_enum);
+            let (from_be_bytes_arms, to_be_bytes_arms) = enums::handle_enum(errors, data_enum.clone());
+            let (from_le_bytes_arms, to_le_bytes_arms) = enums::handle_enum(Vec::new(), data_enum);
 
             let expanded = quote! {
                 impl #my_trait_path for #name {
+                    fn field_size() -> usize {
+                        core::mem::size_of::<Self>()
+                    }
+                    
+                    // Big-endian implementation
                     fn try_from_be_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
                         if bytes.is_empty() {
                             return Err("No bytes provided.".into());
@@ -152,9 +213,26 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                         bytes.push(val);
                         bytes
                     }
+                    
+                    // Little-endian implementation
+                    fn try_from_le_bytes(bytes: &[u8]) -> Result<(Self, usize), Box<dyn std::error::Error>> {
+                        if bytes.is_empty() {
+                            return Err("No bytes provided.".into());
+                        }
+                        let value = bytes[0];
+                        match value {
+                            #(#from_le_bytes_arms)*
+                            _ => Err(format!("No matching variant found for value {}", value).into()),
+                        }
+                    }
 
-                    fn field_size() -> usize {
-                        core::mem::size_of::<Self>()
+                    fn to_le_bytes(&self) -> Vec<u8> {
+                        let mut bytes = Vec::with_capacity(1);
+                        let val = match self {
+                            #(#to_le_bytes_arms)*
+                        };
+                        bytes.push(val);
+                        bytes
                     }
                 }
             };

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -44,6 +44,7 @@ pub struct StructContext<'a> {
     pub fields: &'a syn::FieldsNamed,
     pub total_size: usize,
     pub last_field: Option<&'a syn::Field>,
+    pub endianness: crate::consts::Endianness,
 }
 
 fn push_field_accessor(field_data: &mut FieldData, field_name: &syn::Ident, needs_owned: bool) {
@@ -67,7 +68,7 @@ fn push_byte_indices(tokens: &mut Vec<proc_macro2::TokenStream>, field_size: usi
     });
 }
 
-fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: &mut FieldData) {
+fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: &mut FieldData, endianness: crate::consts::Endianness) {
     let FieldContext {
         field_name,
         field_type,
@@ -96,6 +97,11 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
         }
     });
 
+    let from_bytes_method = utils::get_from_bytes_method(endianness);
+    let to_bytes_method = utils::get_to_bytes_method(endianness);
+    let bit_shift_direction = utils::get_u8_bit_shift_direction(size, pos, endianness);
+    let bit_write_shift = utils::get_u8_bit_write_shift(size, pos, endianness);
+
     if number_length > 1 {
         let chunks =
             utils::generate_chunks(number_length, syn::Ident::new("chunk", Span::call_site()));
@@ -104,7 +110,7 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
             let mut inner_total_size = #pos;
             let mut #field_name = 0 as #field_type;
             bytes.chunks(#number_length).for_each(|chunk| {
-                let u_type = #field_type::from_be_bytes(#chunks);
+                let u_type = #field_type::#from_bytes_method(#chunks);
                 let shift_left = _bit_sum % 8;
                 let left_shifted_u_type = u_type << shift_left;
                 let shift_right = 8 * #number_length - #size;
@@ -127,7 +133,7 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
             let shift_left = (#number_length * 8) - #size;
             let shift_right = (#pos % 8);
             let shifted_masked_value = (masked_value << shift_left) >> shift_right;
-            let byte_values = #field_type::to_be_bytes(shifted_masked_value);
+            let byte_values = #field_type::#to_bytes_method(shifted_masked_value);
             for i in 0..#number_length {
                 if bytes.len() <= _bit_sum / 8 + i {
                     bytes.resize(_bit_sum / 8 + i + 1, 0);
@@ -138,7 +144,7 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
         });
     } else {
         field_data.field_parsing.push(quote! {
-            let #field_name = (bytes[_bit_sum / 8] as #field_type >> (7 - (#size + #pos % 8 - 1) as #field_type )) & (#mask as #field_type);
+            let #field_name = (bytes[_bit_sum / 8] as #field_type >> (#bit_shift_direction as usize) as #field_type) & (#mask as #field_type);
             _bit_sum += #size;
         });
 
@@ -154,7 +160,7 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
             if bytes.len() <= _bit_sum / 8 {
                 bytes.resize(_bit_sum / 8 + 1, 0);
             }
-            bytes[_bit_sum / 8] |= (#field_name as u8) << (7 - (#size - 1) - #pos % 8);
+            bytes[_bit_sum / 8] |= (#field_name as u8) << (#bit_write_shift as usize);
             _bit_sum += #size;
         });
     }
@@ -162,7 +168,7 @@ fn handle_u8_field(context: &FieldContext, size: usize, pos: usize, field_data: 
     field_data.total_size += size;
 }
 
-fn handle_primitive_type(context: &FieldContext, field_data: &mut FieldData) {
+fn handle_primitive_type(context: &FieldContext, field_data: &mut FieldData, endianness: crate::consts::Endianness) {
     let FieldContext {
         field_name,
         field_type,
@@ -181,8 +187,12 @@ fn handle_primitive_type(context: &FieldContext, field_data: &mut FieldData) {
 
     let mut parsing = Vec::new();
     push_byte_indices(&mut parsing, field_size);
+    
+    let from_bytes_method = utils::get_from_bytes_method(endianness);
+    let to_bytes_method = utils::get_to_bytes_method(endianness);
+    
     parsing.push(quote! {
-        let #field_name = <#field_type>::from_be_bytes({
+        let #field_name = <#field_type>::#from_bytes_method({
             let slice = &bytes[byte_index..end_byte_index];
             let mut arr = [0; #field_size];
             arr.copy_from_slice(slice);
@@ -190,9 +200,9 @@ fn handle_primitive_type(context: &FieldContext, field_data: &mut FieldData) {
         });
     });
     field_data.field_parsing.extend(parsing);
-
+    
     field_data.field_writing.push(quote! {
-        let field_slice = &#field_name.to_be_bytes();
+        let field_slice = &#field_name.#to_bytes_method();
         bytes.extend_from_slice(field_slice);
         _bit_sum += field_slice.len() * 8;
     });
@@ -296,7 +306,7 @@ fn handle_vector(
     }
 }
 
-fn handle_option_type(context: &FieldContext, field_data: &mut FieldData) {
+fn handle_option_type(context: &FieldContext, field_data: &mut FieldData, endianness: crate::consts::Endianness) {
     let FieldContext {
         field_name,
         field_type,
@@ -318,13 +328,16 @@ fn handle_option_type(context: &FieldContext, field_data: &mut FieldData) {
 
                     push_bit_sum(field_data, field_size);
 
+                    let from_bytes_method = utils::get_from_bytes_method(endianness);
+                    let to_bytes_method = utils::get_to_bytes_method(endianness);
+
                     let mut parsing = Vec::new();
                     push_byte_indices(&mut parsing, field_size);
                     parsing.push(quote! {
                         let #field_name = if bytes[byte_index..end_byte_index] == [0_u8; #field_size] {
                             None
                         } else {
-                            Some(<#inner_tp>::from_be_bytes({
+                            Some(<#inner_tp>::#from_bytes_method({
                                 let slice = &bytes[byte_index..end_byte_index];
                                 let mut arr = [0; #field_size];
                                 arr.copy_from_slice(slice);
@@ -335,9 +348,9 @@ fn handle_option_type(context: &FieldContext, field_data: &mut FieldData) {
                     field_data.field_parsing.extend(parsing);
 
                     field_data.field_writing.push(quote! {
-                        let be_bytes = &#field_name.unwrap_or(0).to_be_bytes();
-                        bytes.extend_from_slice(be_bytes);
-                        _bit_sum += be_bytes.len() * 8;
+                        let bytes_data = &#field_name.unwrap_or(0).#to_bytes_method();
+                        bytes.extend_from_slice(bytes_data);
+                        _bit_sum += bytes_data.len() * 8;
                     });
                 }
             }
@@ -345,14 +358,14 @@ fn handle_option_type(context: &FieldContext, field_data: &mut FieldData) {
     }
 }
 
-fn handle_custom_type(context: &FieldContext, field_data: &mut FieldData) {
+fn handle_custom_type(context: &FieldContext, field_data: &mut FieldData, endianness: crate::consts::Endianness) {
     let FieldContext {
         field_name,
         field_type,
         field,
         ..
     } = context;
-    // field is needs_owned when type does not implement Copy
+    
     let needs_owned = !utils::is_copy(field_type);
     push_field_accessor(field_data, field_name, needs_owned);
 
@@ -360,20 +373,23 @@ fn handle_custom_type(context: &FieldContext, field_data: &mut FieldData) {
         bit_sum += 8 * #field_type::field_size();
     });
 
+    let try_from_bytes_method = utils::get_try_from_bytes_method(endianness);
+    let to_bytes_method = utils::get_to_bytes_method(endianness);
+
     field_data.field_parsing.push(quote_spanned! { field.span() =>
         byte_index = _bit_sum / 8;
         let predicted_size = #field_type::field_size();
         end_byte_index = usize::min(bytes.len(), byte_index + predicted_size);
-        let (#field_name, bytes_read) = #field_type::try_from_be_bytes(&bytes[byte_index..end_byte_index])?;
+        let (#field_name, bytes_read) = #field_type::#try_from_bytes_method(&bytes[byte_index..end_byte_index])?;
         _bit_sum += bytes_read * 8;
     });
 
     field_data
         .field_writing
         .push(quote_spanned! { field.span() =>
-            let be_bytes = &BeBytes::to_be_bytes(&#field_name);
-            bytes.extend_from_slice(be_bytes);
-            _bit_sum += be_bytes.len() * 8;
+            let bytes_data = &BeBytes::#to_bytes_method(&#field_name);
+            bytes.extend_from_slice(bytes_data);
+            _bit_sum += bytes_data.len() * 8;
         });
 }
 
@@ -453,25 +469,25 @@ pub fn handle_struct(context: StructContext) {
             .map(|last| last.ident == field.ident)
             .unwrap_or(false);
 
-        let context = FieldContext {
+        let field_context = FieldContext {
             field: &field,
             field_name: field.ident.clone().unwrap(),
             field_type: &field.ty,
             is_last_field: is_last,
         };
 
-        match determine_field_type(&context, &field.attrs, &mut field_data.errors) {
+        match determine_field_type(&field_context, &field.attrs, &mut field_data.errors) {
             Some(field_type) => match field_type {
                 FieldType::U8Field(size, pos) => {
-                    handle_u8_field(&context, size, pos, &mut field_data)
+                    handle_u8_field(&field_context, size, pos, &mut field_data, context.endianness)
                 }
-                FieldType::PrimitiveType => handle_primitive_type(&context, &mut field_data),
-                FieldType::Array(length) => handle_array(&context, length, &mut field_data),
+                FieldType::PrimitiveType => handle_primitive_type(&field_context, &mut field_data, context.endianness),
+                FieldType::Array(length) => handle_array(&field_context, length, &mut field_data),
                 FieldType::Vector(size, vec_size_ident) => {
-                    handle_vector(&context, size, vec_size_ident, &mut field_data)
+                    handle_vector(&field_context, size, vec_size_ident, &mut field_data)
                 }
-                FieldType::OptionType => handle_option_type(&context, &mut field_data),
-                FieldType::CustomType => handle_custom_type(&context, &mut field_data),
+                FieldType::OptionType => handle_option_type(&field_context, &mut field_data, context.endianness),
+                FieldType::CustomType => handle_custom_type(&field_context, &mut field_data, context.endianness),
             },
             None => continue,
         }

--- a/bebytes_derive/src/utils.rs
+++ b/bebytes_derive/src/utils.rs
@@ -7,7 +7,42 @@ use std::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::consts::{PRIMITIVES, SUPPORTED_PRIMITIVES};
+use crate::consts::{Endianness, PRIMITIVES, SUPPORTED_PRIMITIVES};
+
+pub fn get_from_bytes_method(endianness: Endianness) -> proc_macro2::TokenStream {
+    match endianness {
+        Endianness::Big => quote! { from_be_bytes },
+        Endianness::Little => quote! { from_le_bytes },
+    }
+}
+
+pub fn get_to_bytes_method(endianness: Endianness) -> proc_macro2::TokenStream {
+    match endianness {
+        Endianness::Big => quote! { to_be_bytes },
+        Endianness::Little => quote! { to_le_bytes },
+    }
+}
+
+pub fn get_try_from_bytes_method(endianness: Endianness) -> proc_macro2::TokenStream {
+    match endianness {
+        Endianness::Big => quote! { try_from_be_bytes },
+        Endianness::Little => quote! { try_from_le_bytes },
+    }
+}
+
+pub fn get_u8_bit_shift_direction(size: usize, pos: usize, endianness: Endianness) -> proc_macro2::TokenStream {
+    match endianness {
+        Endianness::Big => quote! { (7_usize - (#size + #pos % 8_usize - 1_usize)) },
+        Endianness::Little => quote! { #pos % 8_usize },
+    }
+}
+
+pub fn get_u8_bit_write_shift(size: usize, pos: usize, endianness: Endianness) -> proc_macro2::TokenStream {
+    match endianness {
+        Endianness::Big => quote! { (7_usize - (#size - 1_usize) - #pos % 8_usize) },
+        Endianness::Little => quote! { #pos % 8_usize },
+    }
+}
 
 pub fn get_number_size(
     field_type: &syn::Type,

--- a/bebytes_derive/src/utils.rs
+++ b/bebytes_derive/src/utils.rs
@@ -30,14 +30,22 @@ pub fn get_try_from_bytes_method(endianness: Endianness) -> proc_macro2::TokenSt
     }
 }
 
-pub fn get_u8_bit_shift_direction(size: usize, pos: usize, endianness: Endianness) -> proc_macro2::TokenStream {
+pub fn get_u8_bit_shift_direction(
+    size: usize,
+    pos: usize,
+    endianness: Endianness,
+) -> proc_macro2::TokenStream {
     match endianness {
         Endianness::Big => quote! { (7_usize - (#size + #pos % 8_usize - 1_usize)) },
         Endianness::Little => quote! { #pos % 8_usize },
     }
 }
 
-pub fn get_u8_bit_write_shift(size: usize, pos: usize, endianness: Endianness) -> proc_macro2::TokenStream {
+pub fn get_u8_bit_write_shift(
+    size: usize,
+    pos: usize,
+    endianness: Endianness,
+) -> proc_macro2::TokenStream {
     match endianness {
         Endianness::Big => quote! { (7_usize - (#size - 1_usize) - #pos % 8_usize) },
         Endianness::Little => quote! { #pos % 8_usize },


### PR DESCRIPTION
This PR adds little-endian support to the BeBytes trait, allowing users to serialize and deserialize data in either big-endian or little-endian format.

## Changes

- Update the BeBytes trait to include little-endian conversion methods (to_le_bytes() and try_from_le_bytes())
- Implement the derive macro to generate code for little-endian conversion
- Add utility functions for handling endianness-specific operations
- Ensure correct bit operations for both endianness formats
- Add test cases to verify both endianness implementations
- Update documentation to reflect new capabilities

## Benefits

This change allows users to choose the appropriate endianness for their use case at runtime, increasing the flexibility of the library while maintaining backward compatibility.