### PR TITLE
feat\!: Simplify bit field API - Remove manual position tracking

### DIFF
--- a/bebytes/README.md
+++ b/bebytes/README.md
@@ -66,45 +66,47 @@ The BeBytes derive macro generates the following methods for your struct:
 
 ## Bit Field Manipulation
 
-BeBytes provides fine-grained control over bit fields through the `U8` attribute:
+BeBytes provides fine-grained control over bit fields through the `bits` attribute:
 
 ```rust
 #[derive(BeBytes, Debug)]
 struct MyStruct {
-    #[U8(size(1), pos(0))]
-    field1: u8,   // 1 bit at position 0
-    #[U8(size(4), pos(1))]
-    field2: u8,   // 4 bits at position 1
-    #[U8(size(3), pos(5))]
-    field3: u8,   // 3 bits at position 5
+    #[bits(1)]
+    field1: u8,   // 1 bit
+    #[bits(4)]
+    field2: u8,   // 4 bits
+    #[bits(3)]
+    field3: u8,   // 3 bits (total: 8 bits = 1 byte)
     field4: u32,  // Regular 4-byte field
 }
 ```
 
-The `U8` attribute takes two parameters:
+The `bits` attribute takes a single parameter:
 
-- `size(n)`: The number of bits this field uses
-- `pos(n)`: The bit position where this field starts (from left to right, 0-indexed)
+- `bits(n)`: The number of bits this field uses
 
-Fields are read/written sequentially and `U8` fields MUST complete a full byte before the next non-`U8` field. This means the sum of all `size` values within a byte group must be 8 (or a multiple of 8 for multi-byte fields).
+Key points:
+- Bit positions are automatically calculated based on field order
+- Bits fields MUST complete a full byte before any non-bits field
+- The sum of all bits within a group must equal 8 (or a multiple of 8)
 
 ### Multi-Byte Bit Fields
 
-BeBytes supports bit manipulation on all unsigned types from `u8` to `u128`:
+BeBytes supports bit manipulation on all integer types from `u8`/`i8` to `u128`/`i128`:
 
 ```rust
 #[derive(BeBytes, Debug)]
 struct U16Example {
-    #[U8(size(1), pos(0))]
-    flag: u8,
-    #[U8(size(14), pos(1))]
-    value: u16,   // 14-bit value spanning across bytes
-    #[U8(size(1), pos(15))]
-    last_flag: u8,
+    #[bits(1)]
+    flag: u8,     // 1 bit
+    #[bits(14)]
+    value: u16,   // 14 bits spanning across bytes
+    #[bits(1)]
+    last_flag: u8,  // 1 bit (total: 16 bits = 2 bytes)
 }
 ```
 
-The same rules apply - all `U8` fields must complete a byte boundary, even when spanning multiple bytes.
+The same rules apply - all bits fields must complete a byte boundary together.
 
 ## Supported Types
 

--- a/bebytes/bin/macro_test.rs
+++ b/bebytes/bin/macro_test.rs
@@ -315,11 +315,11 @@ fn test_dns_name() {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I8 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(6), pos(1))]
+    #[bits(6)]
     second: i8,
-    #[U8(size(1), pos(7))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -332,31 +332,31 @@ struct F32 {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U128 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(126), pos(1))]
+    #[bits(126)]
     second: u128,
-    #[U8(size(1), pos(127))]
+    #[bits(1)]
     fourth: u8,
 }
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U64 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(62), pos(1))]
+    #[bits(62)]
     second: u64,
-    #[U8(size(1), pos(63))]
+    #[bits(1)]
     fourth: u8,
 }
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct CompleteFunctionality {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(3), pos(1))]
+    #[bits(3)]
     second: u8,
-    #[U8(size(4), pos(4))]
+    #[bits(4)]
     third: u8,
     #[With(size(3))]
     with_size: Vec<u8>,
@@ -375,32 +375,32 @@ struct CompleteFunctionality {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U8 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(3), pos(1))]
+    #[bits(3)]
     second: u8,
-    #[U8(size(4), pos(4))]
+    #[bits(4)]
     third: u8,
     fourth: u8,
 }
 
 #[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
 struct U16 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(14), pos(1))]
+    #[bits(14)]
     second: u16,
-    #[U8(size(1), pos(15))]
+    #[bits(1)]
     fourth: u8,
 }
 
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 struct U32 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(30), pos(1))]
+    #[bits(30)]
     second: u32,
-    #[U8(size(1), pos(31))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -414,30 +414,30 @@ pub enum DummyEnum {
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 pub struct DummyStruct {
     pub dummy0: [u8; 2],
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub dummy1: u8,
-    #[U8(size(7), pos(1))]
+    #[bits(7)]
     pub dummy2: u8,
 }
 
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 pub struct ErrorEstimate {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub s_bit: u8,
-    #[U8(size(1), pos(1))]
+    #[bits(1)]
     pub z_bit: u8,
-    #[U8(size(6), pos(2))]
+    #[bits(6)]
     pub scale: u8,
     pub dummy_struct: DummyStruct,
 }
 
 #[derive(BeBytes, Debug, PartialEq)]
 pub struct ErrorEstimateMini {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub s_bit: u8,
-    #[U8(size(1), pos(1))]
+    #[bits(1)]
     pub z_bit: u8,
-    #[U8(size(6), pos(2))]
+    #[bits(6)]
     pub scale: u8,
     pub multiplier: u32,
 }

--- a/bebytes/bin/macro_test.rs
+++ b/bebytes/bin/macro_test.rs
@@ -10,10 +10,10 @@ fn main() {
     let bytes = client_setup_response.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
     for byte in &bytes {
-        print!("{:08b} ", byte);
+        print!("{byte:08b} ");
     }
     let smalls_father1 = ArrayedStruct::try_from_be_bytes(&bytes);
-    println!("\nSmallStrucFather: {:?}", smalls_father1);
+    println!("\nSmallStrucFather: {smalls_father1:?}");
 
     let small_struct = SmallStruct { small: 3 };
     let smalls_father = SmallStructFather {
@@ -23,10 +23,10 @@ fn main() {
     let bytes = smalls_father.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
     for byte in &bytes {
-        print!("{:08b} ", byte);
+        print!("{byte:08b} ");
     }
     let smalls_father1 = SmallStructFather::try_from_be_bytes(&bytes);
-    println!("\nSmallStrucFather: {:?}", smalls_father1);
+    println!("\nSmallStrucFather: {smalls_father1:?}");
 
     let error_estimate = ErrorEstimateMini {
         s_bit: 1,
@@ -37,10 +37,10 @@ fn main() {
     let bytes = error_estimate.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
     for byte in &bytes {
-        print!("{:08b} ", byte);
+        print!("{byte:08b} ");
     }
     let error = ErrorEstimateMini::try_from_be_bytes(&bytes);
-    println!("\nError: {:?}", error);
+    println!("\nError: {error:?}");
     assert_eq!(error_estimate, error.unwrap().0);
     let error_estimate = ErrorEstimate {
         s_bit: 1,
@@ -55,11 +55,11 @@ fn main() {
     let bytes = error_estimate.to_be_bytes();
     println!("Bytes len: {}", bytes.len());
     for byte in &bytes {
-        print!("{:08b} ", byte);
+        print!("{byte:08b} ");
     }
 
     let error = ErrorEstimate::try_from_be_bytes(&bytes);
-    println!("\nError: {:?}", error);
+    println!("\nError: {error:?}");
     assert_eq!(error_estimate, error.unwrap().0);
     let dummy = DummyStruct {
         dummy0: [0, 2],
@@ -69,13 +69,13 @@ fn main() {
     let dummy_bytes = dummy.to_be_bytes();
 
     let re_dummy = DummyStruct::try_from_be_bytes(&dummy_bytes);
-    println!("\ndummy error {:?}", re_dummy);
+    println!("\ndummy error {re_dummy:?}");
     assert_eq!(dummy, re_dummy.unwrap().0);
     let nested = NestedStruct::new(dummy, None, error_estimate);
     let nested_bytes = nested.to_be_bytes();
     println!("Nested bytes:");
     for byte in &nested_bytes {
-        print!("{:08b} ", byte);
+        print!("{byte:08b} ");
     }
     let dummy_enum = DummyEnum::ServerStart;
     let dummy_enum_bytes = dummy_enum.to_be_bytes();
@@ -89,9 +89,9 @@ fn main() {
         fourth: 4,
     };
     let u_8_bytes = u_8.to_be_bytes();
-    println!("{:?}", u_8_bytes);
+    println!("{u_8_bytes:?}");
     let re_u_8 = U8::try_from_be_bytes(&u_8_bytes);
-    println!("{:?}", re_u_8);
+    println!("{re_u_8:?}");
     assert_eq!(u_8, re_u_8.unwrap().0);
 
     let u_16 = U16 {
@@ -101,9 +101,9 @@ fn main() {
     };
     let u_16_bytes = u_16.to_be_bytes();
 
-    println!("{:?}", u_16_bytes);
+    println!("{u_16_bytes:?}");
     let re_u_16 = U16::try_from_be_bytes(&u_16_bytes);
-    println!("{:?}", re_u_16);
+    println!("{re_u_16:?}");
     assert_eq!(u_16, re_u_16.unwrap().0);
 
     let u_32 = U32 {
@@ -113,30 +113,30 @@ fn main() {
     };
     let u_32_bytes = u_32.to_be_bytes();
 
-    println!("{:?}", u_32_bytes);
+    println!("{u_32_bytes:?}");
     let re_u_32 = U32::try_from_be_bytes(&u_32_bytes);
-    println!("{:?}", re_u_32);
+    println!("{re_u_32:?}");
     assert_eq!(u_32, re_u_32.unwrap().0);
 
     let optional = Optional {
         optional_number: Some(5),
     };
     let optional_bytes = optional.to_be_bytes();
-    println!("Optional Some: {:?}", optional_bytes);
+    println!("Optional Some: {optional_bytes:?}");
     let none_optional = Optional {
         optional_number: None,
     };
     let none_optional_bytes = none_optional.to_be_bytes();
-    println!("Optional None: {:?}", none_optional_bytes);
+    println!("Optional None: {none_optional_bytes:?}");
     let with_tailing_vec = WithTailingVec {
         pre_tail: 2,
         tail: vec![2, 3],
         post_tail: 3,
     };
     let with_tailing_vec_bytes = with_tailing_vec.to_be_bytes();
-    println!("WithTailingVec: {:?}", with_tailing_vec_bytes);
+    println!("WithTailingVec: {with_tailing_vec_bytes:?}");
     let re_with_tailing_vec = WithTailingVec::try_from_be_bytes(&with_tailing_vec_bytes);
-    println!("ReWithTailingVec: {:?}", re_with_tailing_vec);
+    println!("ReWithTailingVec: {re_with_tailing_vec:?}");
     assert_eq!(with_tailing_vec, re_with_tailing_vec.unwrap().0);
 
     let with_size_struct = WithSizeStruct {
@@ -144,9 +144,9 @@ fn main() {
         real_tail: vec![2, 3, 4],
     };
     let with_size_struct_bytes = with_size_struct.to_be_bytes();
-    println!("WithSizeStruct: {:?}", with_size_struct_bytes);
+    println!("WithSizeStruct: {with_size_struct_bytes:?}");
     let re_with_size_struct = WithSizeStruct::try_from_be_bytes(&with_size_struct_bytes);
-    println!("ReWithSizeStruct: {:?}", re_with_size_struct);
+    println!("ReWithSizeStruct: {re_with_size_struct:?}");
     assert_eq!(with_size_struct, re_with_size_struct.unwrap().0);
 
     let innocent_struct = InnocentStruct {
@@ -154,9 +154,9 @@ fn main() {
         real_tail: vec![4, 5],
     };
     let innocent_struct_bytes = innocent_struct.to_be_bytes();
-    println!("InnocentStruct: {:?}", innocent_struct_bytes);
+    println!("InnocentStruct: {innocent_struct_bytes:?}");
     let re_innocent_struct = InnocentStruct::try_from_be_bytes(&innocent_struct_bytes);
-    println!("ReInnocentStruct: {:?}", re_innocent_struct);
+    println!("ReInnocentStruct: {re_innocent_struct:?}");
     assert_eq!(innocent_struct, re_innocent_struct.unwrap().0);
 
     let complete_func = CompleteFunctionality::new(
@@ -180,9 +180,9 @@ fn main() {
         vec![1, 2, 3, 4, 5],
     );
     let complete_func_bytes = complete_func.to_be_bytes();
-    println!("CompleteFunctionality: {:?}", complete_func_bytes);
+    println!("CompleteFunctionality: {complete_func_bytes:?}");
     let re_complete_func = CompleteFunctionality::try_from_be_bytes(&complete_func_bytes);
-    println!("ReCompleteFunctionality: {:?}", re_complete_func);
+    println!("ReCompleteFunctionality: {re_complete_func:?}");
     assert_eq!(complete_func, re_complete_func.unwrap().0);
     let u_64 = U64 {
         first: 1,
@@ -190,9 +190,9 @@ fn main() {
         fourth: 1,
     };
     let u_64_bytes = u_64.to_be_bytes();
-    println!("{:?}", u_64_bytes);
+    println!("{u_64_bytes:?}");
     let re_u_64 = U64::try_from_be_bytes(&u_64_bytes);
-    println!("{:?}", re_u_64);
+    println!("{re_u_64:?}");
     assert_eq!(u_64, re_u_64.unwrap().0);
 
     let u_128 = U128 {
@@ -201,9 +201,9 @@ fn main() {
         fourth: 1,
     };
     let u_128_bytes = u_128.to_be_bytes();
-    println!("{:?}", u_128_bytes);
+    println!("{u_128_bytes:?}");
     let re_u_128 = U128::try_from_be_bytes(&u_128_bytes);
-    println!("{:?}", re_u_128);
+    println!("{re_u_128:?}");
     assert_eq!(u_128, re_u_128.unwrap().0);
 
     let i_8 = I8 {
@@ -212,9 +212,9 @@ fn main() {
         fourth: 1,
     };
     let i_8_bytes = i_8.to_be_bytes();
-    println!("{:?}", i_8_bytes);
+    println!("{i_8_bytes:?}");
     let re_i_8 = I8::try_from_be_bytes(&i_8_bytes);
-    println!("{:?}", re_i_8);
+    println!("{re_i_8:?}");
     assert_eq!(i_8, re_i_8.unwrap().0);
 
     // Test Dns type
@@ -234,11 +234,11 @@ fn test_both_endianness() {
 
     // Convert to big-endian
     let be_bytes = test_struct.to_be_bytes();
-    println!("Big-endian bytes: {:?}", be_bytes);
+    println!("Big-endian bytes: {be_bytes:?}");
 
     // Convert to little-endian
     let le_bytes = test_struct.to_le_bytes();
-    println!("Little-endian bytes: {:?}", le_bytes);
+    println!("Little-endian bytes: {le_bytes:?}");
 
     // They should be different
     assert_ne!(
@@ -248,12 +248,12 @@ fn test_both_endianness() {
 
     // Parse from big-endian
     let (from_be, be_len) = U16::try_from_be_bytes(&be_bytes).unwrap();
-    println!("Parsed from BE: {:?}, len: {}", from_be, be_len);
+    println!("Parsed from BE: {from_be:?}, len: {be_len}");
     assert_eq!(test_struct, from_be);
 
     // Parse from little-endian
     let (from_le, le_len) = U16::try_from_le_bytes(&le_bytes).unwrap();
-    println!("Parsed from LE: {:?}, len: {}", from_le, le_len);
+    println!("Parsed from LE: {from_le:?}, len: {le_len}");
     assert_eq!(test_struct, from_le);
 
     // Parsing big-endian as little-endian should yield incorrect results
@@ -262,7 +262,7 @@ fn test_both_endianness() {
             test_struct, wrong_endian,
             "Parsing BE bytes as LE should give different results"
         );
-        println!("BE bytes parsed as LE (incorrectly): {:?}", wrong_endian);
+        println!("BE bytes parsed as LE (incorrectly): {wrong_endian:?}");
     }
 
     // Test with a medium complexity struct (U32)
@@ -274,13 +274,13 @@ fn test_both_endianness() {
 
     // Test big-endian serialization and deserialization
     let u32_be = test_u32.to_be_bytes();
-    println!("U32 BE bytes: {:?}", u32_be);
+    println!("U32 BE bytes: {u32_be:?}");
     let (parsed_u32_be, _) = U32::try_from_be_bytes(&u32_be).unwrap();
     assert_eq!(test_u32, parsed_u32_be);
 
     // Test little-endian serialization and deserialization
     let u32_le = test_u32.to_le_bytes();
-    println!("U32 LE bytes: {:?}", u32_le);
+    println!("U32 LE bytes: {u32_le:?}");
     let (parsed_u32_le, _) = U32::try_from_le_bytes(&u32_le).unwrap();
     assert_eq!(test_u32, parsed_u32_le);
 
@@ -304,12 +304,12 @@ fn test_dns_name() {
         ],
     };
     let bytes = dns_name.to_be_bytes();
-    println!("DNS Name bytes: {:?}", bytes);
+    println!("DNS Name bytes: {bytes:?}");
     let re_dns_name = DnsName::try_from_be_bytes(&bytes);
-    println!("Reconstructed DNS Name: {:?}", re_dns_name);
+    println!("Reconstructed DNS Name: {re_dns_name:?}");
     assert_eq!(dns_name, re_dns_name.unwrap().0);
     let re_dns_name = DnsName::try_from_le_bytes(&bytes);
-    println!("Reconstructed DNS Name (LE): {:?}", re_dns_name);
+    println!("Reconstructed DNS Name (LE): {re_dns_name:?}");
     assert_eq!(dns_name, re_dns_name.unwrap().0);
 }
 

--- a/bebytes/tests/compile_time/incomplete_byte.rs
+++ b/bebytes/tests/compile_time/incomplete_byte.rs
@@ -5,11 +5,12 @@ extern crate alloc;
 use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
-struct Char {
-    #[U8(size(4), pos(0))]
+struct IncompleteByte {
+    #[bits(3)]
     first: u8,
-    #[U8(size(4), pos(3))]
+    #[bits(4)]
     second: u8,
+    // Total: 7 bits - not a complete byte!
 }
 
 fn main() {}

--- a/bebytes/tests/compile_time/incomplete_byte.stderr
+++ b/bebytes/tests/compile_time/incomplete_byte.stderr
@@ -1,0 +1,11 @@
+error: bits attributes must complete a full byte. Total bits: 7, which is 1 bits short of a complete byte
+  --> tests/compile_time/incomplete_byte.rs:8:23
+   |
+8  |   struct IncompleteByte {
+   |  _______________________^
+9  | |     #[bits(3)]
+10 | |     first: u8,
+11 | |     #[bits(4)]
+...  |
+14 | | }
+   | |_^

--- a/bebytes/tests/compile_time/nested_struct.rs
+++ b/bebytes/tests/compile_time/nested_struct.rs
@@ -12,9 +12,9 @@ pub struct NestedStruct {
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 pub struct DummyStruct {
     pub dummy0: [u8; 2],
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub dummy1: u8,
-    #[U8(size(7), pos(1))]
+    #[bits(7)]
     pub dummy2: u8,
 }
 

--- a/bebytes/tests/compile_time/overlap.stderr
+++ b/bebytes/tests/compile_time/overlap.stderr
@@ -1,6 +1,0 @@
-error: U8 attributes must obey the sequence specified by the previous attributes. Expected position 4 but got 3
-  --> tests/compile_time/overlap.rs:11:5
-   |
-11 | /     #[U8(size(4), pos(3))]
-12 | |     second: u8,
-   | |______________^

--- a/bebytes/tests/compile_time/test_u16s.rs
+++ b/bebytes/tests/compile_time/test_u16s.rs
@@ -7,11 +7,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
 struct U16 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(14), pos(1))]
+    #[bits(14)]
     second: u16,
-    #[U8(size(1), pos(15))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/compile_time/test_u32s.rs
+++ b/bebytes/tests/compile_time/test_u32s.rs
@@ -7,11 +7,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 struct U32 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(30), pos(1))]
+    #[bits(30)]
     second: u32,
-    #[U8(size(1), pos(31))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/compile_time/test_u8s.rs
+++ b/bebytes/tests/compile_time/test_u8s.rs
@@ -6,11 +6,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U8 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(3), pos(1))]
+    #[bits(3)]
     second: u8,
-    #[U8(size(4), pos(4))]
+    #[bits(4)]
     third: u8,
     fourth: u8,
 }

--- a/bebytes/tests/compile_time/unsupported_char.rs
+++ b/bebytes/tests/compile_time/unsupported_char.rs
@@ -6,11 +6,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct Char {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(6), pos(1))]
+    #[bits(6)]
     second: char,
-    #[U8(size(1), pos(7))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/compile_time/unsupported_char.stderr
+++ b/bebytes/tests/compile_time/unsupported_char.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for U8 attribute
+error: Unsupported type for bits attribute
   --> tests/compile_time/unsupported_char.rs:12:13
    |
 12 |     second: char,

--- a/bebytes/tests/compile_time/unsupported_f64.rs
+++ b/bebytes/tests/compile_time/unsupported_f64.rs
@@ -6,11 +6,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct F64 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(62), pos(1))]
+    #[bits(62)]
     second: f64,
-    #[U8(size(1), pos(63))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/compile_time/unsupported_f64.stderr
+++ b/bebytes/tests/compile_time/unsupported_f64.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for U8 attribute
+error: Unsupported type for bits attribute
   --> tests/compile_time/unsupported_f64.rs:12:13
    |
 12 |     second: f64,

--- a/bebytes/tests/compile_time/unsupported_isize.rs
+++ b/bebytes/tests/compile_time/unsupported_isize.rs
@@ -6,11 +6,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct ISize {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(62), pos(1))]
+    #[bits(62)]
     second: isize,
-    #[U8(size(1), pos(63))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/compile_time/unsupported_isize.stderr
+++ b/bebytes/tests/compile_time/unsupported_isize.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for U8 attribute
+error: Unsupported type for bits attribute
   --> tests/compile_time/unsupported_isize.rs:12:13
    |
 12 |     second: isize,

--- a/bebytes/tests/compile_time_tests.rs
+++ b/bebytes/tests/compile_time_tests.rs
@@ -4,7 +4,7 @@ use trybuild::TestCases;
 fn ui_tests() {
     let t = TestCases::new();
     // Failure tests
-    t.compile_fail("tests/compile_time/overlap.rs");
+    t.compile_fail("tests/compile_time/incomplete_byte.rs");
     t.compile_fail("tests/compile_time/unsupported_structure.rs");
     t.compile_fail("tests/compile_time/unsupported_f64.rs");
     t.compile_fail("tests/compile_time/unsupported_char.rs");

--- a/bebytes/tests/runtime_tests.rs
+++ b/bebytes/tests/runtime_tests.rs
@@ -8,11 +8,11 @@ use core::fmt::Write;
 
 #[derive(BeBytes, Debug, PartialEq)]
 pub struct ErrorEstimate {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub s_bit: u8,
-    #[U8(size(1), pos(1))]
+    #[bits(1)]
     pub z_bit: u8,
-    #[U8(size(6), pos(2))]
+    #[bits(6)]
     pub scale: u8,
     pub multiplier: u32,
 }
@@ -112,11 +112,11 @@ fn test_arrays(input: ClientSetupResponse, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq, Clone, Default)]
 pub struct NestedStruct {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub s_bit: u8,
-    #[U8(size(1), pos(1))]
+    #[bits(1)]
     pub z_bit: u8,
-    #[U8(size(6), pos(2))]
+    #[bits(6)]
     pub scale: u8,
     pub dummy_struct: DummyStruct,
 }
@@ -124,9 +124,9 @@ pub struct NestedStruct {
 #[derive(BeBytes, Debug, PartialEq, Clone, Default)]
 pub struct DummyStruct {
     pub dummy0: [u8; 2],
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     pub dummy1: u8,
-    #[U8(size(7), pos(1))]
+    #[bits(7)]
     pub dummy2: u8,
 }
 
@@ -211,11 +211,11 @@ fn test_with_size_attribute(input: WithSizeAttribute, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U16 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(14), pos(1))]
+    #[bits(14)]
     second: u16,
-    #[U8(size(1), pos(15))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -229,11 +229,11 @@ fn test_u16(input: U16, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U32 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(30), pos(1))]
+    #[bits(30)]
     second: u32,
-    #[U8(size(1), pos(31))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -247,11 +247,11 @@ fn test_u32(input: U32, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U64 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(62), pos(1))]
+    #[bits(62)]
     second: u64,
-    #[U8(size(1), pos(63))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -265,11 +265,11 @@ fn test_u64(input: U64, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct U128 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(126), pos(1))]
+    #[bits(126)]
     second: u128,
-    #[U8(size(1), pos(127))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -283,11 +283,11 @@ fn test_u128(input: U128, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I8 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(6), pos(1))]
+    #[bits(6)]
     second: i8,
-    #[U8(size(1), pos(7))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -301,11 +301,11 @@ fn test_i8(input: I8, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I16 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(14), pos(1))]
+    #[bits(14)]
     second: i16,
-    #[U8(size(1), pos(15))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -319,11 +319,11 @@ fn test_i16(input: I16, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I32 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(30), pos(1))]
+    #[bits(30)]
     second: i32,
-    #[U8(size(1), pos(31))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -337,11 +337,11 @@ fn test_i32(input: I32, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I64 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(62), pos(1))]
+    #[bits(62)]
     second: i64,
-    #[U8(size(1), pos(63))]
+    #[bits(1)]
     fourth: u8,
 }
 
@@ -355,11 +355,11 @@ fn test_i64(input: I64, len: usize) {
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct I128 {
-    #[U8(size(1), pos(0))]
+    #[bits(1)]
     first: u8,
-    #[U8(size(126), pos(1))]
+    #[bits(126)]
     second: i128,
-    #[U8(size(1), pos(127))]
+    #[bits(1)]
     fourth: u8,
 }
 

--- a/bebytes/tests/runtime_tests.rs
+++ b/bebytes/tests/runtime_tests.rs
@@ -134,8 +134,7 @@ pub struct DummyStruct {
 fn test_nested_struct(input: NestedStruct, len: usize) {
     let bytes = input.clone().to_be_bytes();
     for byte in bytes.iter() {
-        print!("{:08b} ", *byte);
-        print!("\n");
+        println!("{:08b} ", *byte);
     }
     println!("bytes: {:?}, len: {}", bytes, bytes.len());
     let (nested_struct, written_len) = NestedStruct::try_from_be_bytes(&bytes).unwrap();

--- a/bebytes_derive/src/bit_validation.rs
+++ b/bebytes_derive/src/bit_validation.rs
@@ -1,104 +1,38 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-use std::collections::HashMap;
-use std::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap as HashMap, vec::Vec};
-
 use proc_macro2::TokenStream;
 
-#[derive(Debug, Clone)]
-struct BitRange {
-    start: usize,
-    end: usize,
-}
-
-impl BitRange {
-    fn new(pos: usize, size: usize) -> Self {
-        BitRange {
-            start: pos,
-            end: pos + size - 1,
-        }
-    }
-
-    fn overlaps(&self, other: &BitRange) -> bool {
-        (self.start <= other.start && other.start <= self.end)
-            || (other.start <= self.start && self.start <= other.end)
-    }
-}
-
-pub fn validate_field_sequence(fields: &syn::FieldsNamed) -> Result<(), TokenStream> {
-    let mut total_size = 0;
-    let mut current_byte_ranges: HashMap<usize, Vec<BitRange>> = HashMap::new();
+pub fn validate_byte_completeness(fields: &syn::FieldsNamed) -> Result<(), TokenStream> {
+    let mut total_bits = 0;
 
     for field in &fields.named {
         for attr in &field.attrs {
-            if attr.path().is_ident("U8") {
-                let mut pos = None;
-                let mut size = None;
-
-                if let Err(e) = attr.parse_nested_meta(|meta| {
-                    if meta.path.is_ident("pos") {
-                        let content;
-                        syn::parenthesized!(content in meta.input);
-                        let lit: syn::LitInt = content.parse()?;
-                        pos = Some(lit.base10_parse()?);
-                    } else if meta.path.is_ident("size") {
-                        let content;
-                        syn::parenthesized!(content in meta.input);
-                        let lit: syn::LitInt = content.parse()?;
-                        size = Some(lit.base10_parse()?);
-                    }
-                    Ok(())
-                }) {
-                    return Err(e.to_compile_error());
-                }
-
-                if let (Some(pos), Some(size)) = (pos, size) {
-                    // Check position sequence
-                    if pos % 8 != total_size % 8 {
-                        return Err(syn::Error::new_spanned(field,
-                            format_args!("U8 attributes must obey the sequence specified by the previous attributes. Expected position {} but got {}", 
-                                total_size,
-                                pos
-                            )
-                        ).to_compile_error());
-                    }
-                    // Check for overlaps
-                    let new_range = BitRange::new(pos, size);
-                    let byte_idx = pos / 8;
-
-                    if let Some(ranges) = current_byte_ranges.get(&byte_idx) {
-                        for existing_range in ranges {
-                            if new_range.overlaps(existing_range) {
-                                return Err(syn::Error::new_spanned(
-                                    field,
-                                    format_args!(
-                                        "Bit ranges overlap: positions {}-{} overlap with {}-{}",
-                                        new_range.start,
-                                        new_range.end,
-                                        existing_range.start,
-                                        existing_range.end
-                                    ),
-                                )
-                                .to_compile_error());
-                            }
+            if attr.path().is_ident("bits") {
+                // Parse #[bits(N)] where N is the size
+                match attr.parse_args::<syn::LitInt>() {
+                    Ok(lit) => {
+                        match lit.base10_parse::<usize>() {
+                            Ok(n) => total_bits += n,
+                            Err(e) => return Err(e.to_compile_error()),
                         }
                     }
-
-                    // Add new range to current byte
-                    current_byte_ranges
-                        .entry(byte_idx)
-                        .or_default()
-                        .push(new_range);
-
-                    // Update total size
-                    total_size += size;
+                    Err(e) => return Err(e.to_compile_error()),
                 }
             }
         }
+    }
+
+    // Check if bits complete a full byte
+    if total_bits % 8 != 0 {
+        return Err(syn::Error::new_spanned(
+            fields,
+            format!(
+                "bits attributes must complete a full byte. Total bits: {}, which is {} bits short of a complete byte",
+                total_bits,
+                8 - (total_bits % 8)
+            ),
+        )
+        .to_compile_error());
     }
 
     Ok(())

--- a/bebytes_derive/src/bit_validation.rs
+++ b/bebytes_derive/src/bit_validation.rs
@@ -10,12 +10,10 @@ pub fn validate_byte_completeness(fields: &syn::FieldsNamed) -> Result<(), Token
             if attr.path().is_ident("bits") {
                 // Parse #[bits(N)] where N is the size
                 match attr.parse_args::<syn::LitInt>() {
-                    Ok(lit) => {
-                        match lit.base10_parse::<usize>() {
-                            Ok(n) => total_bits += n,
-                            Err(e) => return Err(e.to_compile_error()),
-                        }
-                    }
+                    Ok(lit) => match lit.base10_parse::<usize>() {
+                        Ok(n) => total_bits += n,
+                        Err(e) => return Err(e.to_compile_error()),
+                    },
                     Err(e) => return Err(e.to_compile_error()),
                 }
             }

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 
 use consts::Endianness;
 
-#[proc_macro_derive(BeBytes, attributes(U8, With, FromField))]
+#[proc_macro_derive(BeBytes, attributes(bits, With, FromField))]
 pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident.clone();

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -556,7 +556,8 @@ fn determine_field_type(
 
 pub fn handle_struct(context: StructContext) {
     // First validate byte completeness
-    if let Err(validation_error) = crate::bit_validation::validate_byte_completeness(context.fields) {
+    if let Err(validation_error) = crate::bit_validation::validate_byte_completeness(context.fields)
+    {
         context.errors.push(validation_error);
         return;
     }

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -9,7 +9,7 @@ use std::vec::Vec;
 use alloc::vec::Vec;
 
 enum FieldType {
-    U8Field(usize, usize), // size, position
+    BitsField(usize), // only size, position is auto-calculated
     PrimitiveType,
     Array(usize),                              // array_length
     Vector(Option<usize>, Option<syn::Ident>), // size, vec_size_ident
@@ -68,12 +68,12 @@ fn push_byte_indices(tokens: &mut Vec<proc_macro2::TokenStream>, field_size: usi
     });
 }
 
-fn handle_u8_field(
+fn handle_bits_field(
     context: &FieldContext,
     size: usize,
-    pos: usize,
     field_data: &mut FieldData,
     endianness: crate::consts::Endianness,
+    current_bit_position: &mut usize,
 ) {
     let FieldContext {
         field_name,
@@ -102,6 +102,10 @@ fn handle_u8_field(
             );
         }
     });
+
+    // Auto-calculate position based on current_bit_position
+    let pos = *current_bit_position;
+    *current_bit_position += size;
 
     let from_bytes_method = utils::get_from_bytes_method(endianness);
     let to_bytes_method = utils::get_to_bytes_method(endianness);
@@ -502,23 +506,23 @@ fn determine_field_type(
     attrs: &[syn::Attribute],
     errors: &mut Vec<proc_macro2::TokenStream>,
 ) -> Option<FieldType> {
-    let mut u8_attribute_present = false;
-    let (pos, size, vec_size_ident) =
-        attrs::parse_attributes(attrs.to_vec(), &mut u8_attribute_present, errors);
+    let mut bits_attribute_present = false;
+    let (size, vec_size_ident) =
+        attrs::parse_attributes(attrs.to_vec(), &mut bits_attribute_present, errors);
 
-    if u8_attribute_present {
+    if bits_attribute_present {
         if let syn::Type::Path(tp) = context.field_type {
             if !utils::is_supported_primitive_type(tp) {
                 let error = syn::Error::new(
                     context.field_type.span(),
-                    "Unsupported type for U8 attribute",
+                    "Unsupported type for bits attribute",
                 );
                 errors.push(error.to_compile_error());
                 return None;
             }
         }
-        if let (Some(pos), Some(size)) = (pos, size) {
-            return Some(FieldType::U8Field(size, pos));
+        if let Some(size) = size {
+            return Some(FieldType::BitsField(size));
         }
         return None;
     }
@@ -551,8 +555,8 @@ fn determine_field_type(
 }
 
 pub fn handle_struct(context: StructContext) {
-    // First validate bit ranges
-    if let Err(validation_error) = crate::bit_validation::validate_field_sequence(context.fields) {
+    // First validate byte completeness
+    if let Err(validation_error) = crate::bit_validation::validate_byte_completeness(context.fields) {
         context.errors.push(validation_error);
         return;
     }
@@ -566,6 +570,9 @@ pub fn handle_struct(context: StructContext) {
         named_fields: Vec::new(),
         total_size: context.total_size,
     };
+
+    // Track current bit position for auto-calculation
+    let mut current_bit_position = 0;
 
     for field in context.fields.named.clone() {
         let is_last = context
@@ -582,12 +589,12 @@ pub fn handle_struct(context: StructContext) {
 
         match determine_field_type(&field_context, &field.attrs, &mut field_data.errors) {
             Some(field_type) => match field_type {
-                FieldType::U8Field(size, pos) => handle_u8_field(
+                FieldType::BitsField(size) => handle_bits_field(
                     &field_context,
                     size,
-                    pos,
                     &mut field_data,
                     context.endianness,
+                    &mut current_bit_position,
                 ),
                 FieldType::PrimitiveType => {
                     handle_primitive_type(&field_context, &mut field_data, context.endianness)


### PR DESCRIPTION
## Summary
- Simplified the bit field API by removing the need for manual position specification
- Positions are now automatically calculated based on declaration order
- **BREAKING CHANGE**: Changes attribute syntax from `#[U8(size(N), pos(X))]` to `#[bits(N)]`

## Breaking Changes
This PR introduces breaking API changes:
- The `U8` attribute has been renamed to `bits`
- The `pos` parameter has been removed entirely
- Positions are now automatically calculated based on field declaration order

### Migration Guide
```rust
// Before
#[derive(BeBytes)]
struct MyStruct {
    #[U8(size(3), pos(0))]
    first: u8,
    #[U8(size(5), pos(3))]
    second: u8,
}

// After
#[derive(BeBytes)]
struct MyStruct {
    #[bits(3)]
    first: u8,
    #[bits(5)]
    second: u8,
}
```

## Version Bump Required
Due to the breaking nature of these changes, both crates will need major version bumps:
- `bebytes`: 0.7.1 → 1.0.0
- `bebytes_derive`: 0.8.1 → 1.0.0

The version bump should be done using the GitHub Actions workflows after this PR is merged.

## Test Plan
- [x] All existing tests have been updated to use the new syntax
- [x] Tests pass successfully
- [x] Added test for incomplete byte validation
- [x] Removed overlap test (no longer possible with auto-positioning)
- [x] Documentation has been updated

## Changes Made
- Modified derive macro to use `bits` attribute instead of `U8`
- Removed position parsing and validation logic
- Updated all error messages to use "bits" terminology
- Simplified attribute parsing to only handle size parameter
- Updated all tests and documentation to use new syntax