### PR TITLE
chore: Bump bebytes_derive to 1.0.0 and update dependency

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -14,7 +14,7 @@ name = "macro_test"
 path = "./bin/macro_test.rs"
 
 [dependencies]
-bebytes_derive = "0.8.1"
+bebytes_derive = "1.0.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "0.8.1"
+version = "1.0.0"
 edition = "2021"
 publish = true
 license = "MIT"


### PR DESCRIPTION
This PR updates the versions in preparation for the 1.0.0 release:

- Bumps bebytes_derive from 0.8.1 to 1.0.0
- Updates bebytes to depend on bebytes_derive 1.0.0

This is needed after the breaking API change that replaced `#[U8(size, pos)]` with `#[bits(N)]`.

## Next Steps
After this PR is merged:
1. Run the "Bump Version bebytes" workflow with "major" to bump bebytes to 1.0.0
2. Publish bebytes_derive 1.0.0 to crates.io
3. Publish bebytes 1.0.0 to crates.io