### PR TITLE
chore: Bump bebytes to 1.0.0

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "0.7.1"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"


### PR DESCRIPTION
This PR bumps bebytes from 0.7.1 to 1.0.0 for the breaking change release.

## Breaking Changes
This release includes the simplified bits API:
- Changed from `#[U8(size(N), pos(X))]` to `#[bits(N)]`
- Positions are now automatically calculated based on field declaration order
- Removed possibility of position overlap errors

## Publishing Order
After this PR is merged:
1. Publish bebytes_derive 1.0.0 to crates.io first
2. Then publish bebytes 1.0.0 to crates.io

The order is important because bebytes 1.0.0 depends on bebytes_derive 1.0.0.