### PR TITLE
chore: bump bebytes_derive to 1.1.1 with correct documentation

### DIFF
--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 publish = true
 license = "MIT"


### PR DESCRIPTION
Bump version to 1.1.1 to re-publish with the updated README that contains the correct  syntax instead of the outdated  syntax.