### PR TITLE
chore: update bebytes to use bebytes_derive 1.1.1 and bump to 1.1.0

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -14,7 +14,7 @@ name = "macro_test"
 path = "./bin/macro_test.rs"
 
 [dependencies]
-bebytes_derive = "1.1.0"
+bebytes_derive = "1.1.1"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }


### PR DESCRIPTION
## Summary
- Update bebytes dependency to use bebytes_derive 1.1.1
- Bump bebytes version to 1.1.0

## Changes
- Update bebytes_derive dependency from 1.1.0 to 1.1.1
- Bump bebytes version from 1.0.0 to 1.1.0

## Test Plan
- [x] All tests pass
- [x] macro_test binary runs successfully
- [x] No breaking changes to existing functionality