### PR TITLE
feat: add enum bit operations and auto-sizing support

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -14,7 +14,7 @@ name = "macro_test"
 path = "./bin/macro_test.rs"
 
 [dependencies]
-bebytes_derive = "1.1.1"
+bebytes_derive = "1.2.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes/tests/compile_time/unsupported_char.stderr
+++ b/bebytes/tests/compile_time/unsupported_char.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for bits attribute
+error: Unsupported type for bits attribute. Only integer types (u8, i8, u16, i16, u32, i32, u64, i64, u128, i128) are supported
   --> tests/compile_time/unsupported_char.rs:12:13
    |
 12 |     second: char,

--- a/bebytes/tests/compile_time/unsupported_f64.stderr
+++ b/bebytes/tests/compile_time/unsupported_f64.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for bits attribute
+error: Unsupported type for bits attribute. Only integer types (u8, i8, u16, i16, u32, i32, u64, i64, u128, i128) are supported
   --> tests/compile_time/unsupported_f64.rs:12:13
    |
 12 |     second: f64,

--- a/bebytes/tests/compile_time/unsupported_isize.stderr
+++ b/bebytes/tests/compile_time/unsupported_isize.stderr
@@ -1,4 +1,4 @@
-error: Unsupported type for bits attribute
+error: Unsupported type for bits attribute. Only integer types (u8, i8, u16, i16, u32, i32, u64, i64, u128, i128) are supported
   --> tests/compile_time/unsupported_isize.rs:12:13
    |
 12 |     second: isize,

--- a/bebytes/tests/test_auto_enum_bits.rs
+++ b/bebytes/tests/test_auto_enum_bits.rs
@@ -1,0 +1,135 @@
+use bebytes::BeBytes;
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum Status {
+    Idle = 0,
+    Running = 1,
+    Paused = 2,
+    Stopped = 3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum Priority {
+    Low = 0,
+    Medium = 1,
+    High = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+struct PacketWithAutoEnums {
+    #[bits(4)]
+    header: u8,
+    #[bits()] // Auto-sized to Status::__BEBYTES_MIN_BITS (2 bits)
+    status: Status,
+    #[bits()] // Auto-sized to Priority::__BEBYTES_MIN_BITS (2 bits)
+    priority: Priority,
+}
+
+#[test]
+fn test_auto_sized_enum_bits() {
+    // Test that constants are generated correctly
+    assert_eq!(Status::__BEBYTES_MIN_BITS, 2); // 4 variants need 2 bits
+    assert_eq!(Priority::__BEBYTES_MIN_BITS, 2); // 3 variants need 2 bits
+
+    // Test TryFrom<u8> implementation
+    assert_eq!(Status::try_from(0u8).unwrap(), Status::Idle);
+    assert_eq!(Status::try_from(1u8).unwrap(), Status::Running);
+    assert_eq!(Status::try_from(2u8).unwrap(), Status::Paused);
+    assert_eq!(Status::try_from(3u8).unwrap(), Status::Stopped);
+    assert!(Status::try_from(4u8).is_err());
+
+    assert_eq!(Priority::try_from(0u8).unwrap(), Priority::Low);
+    assert_eq!(Priority::try_from(1u8).unwrap(), Priority::Medium);
+    assert_eq!(Priority::try_from(2u8).unwrap(), Priority::High);
+    assert!(Priority::try_from(3u8).is_err());
+
+    // Test serialization/deserialization
+    let packet = PacketWithAutoEnums {
+        header: 0b1010,
+        status: Status::Running,
+        priority: Priority::High,
+    };
+
+    // Big-endian test
+    let be_bytes = packet.to_be_bytes();
+    assert_eq!(be_bytes.len(), 1); // All fields fit in 1 byte (4+2+2 = 8 bits)
+
+    // Verify bit layout: header(4) | status(2) | priority(2)
+    // 1010 | 01 | 10 = 0b10100110 = 166
+    assert_eq!(be_bytes[0], 0b10100110);
+
+    let (deserialized, bytes_read) = PacketWithAutoEnums::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(bytes_read, 1);
+    assert_eq!(deserialized.header, 0b1010);
+    assert_eq!(deserialized.status, Status::Running);
+    assert_eq!(deserialized.priority, Priority::High);
+
+    // Little-endian test
+    let le_bytes = packet.to_le_bytes();
+    assert_eq!(le_bytes.len(), 1);
+
+    // In little-endian, bits within a byte are still laid out the same way
+    // But we read from LSB first: priority(2) | status(2) | header(4)
+    // 10 | 01 | 1010 = 0b10011010 = 154
+    assert_eq!(le_bytes[0], 0b10011010);
+
+    let (deserialized, bytes_read) = PacketWithAutoEnums::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(bytes_read, 1);
+    assert_eq!(deserialized.header, 0b1010);
+    assert_eq!(deserialized.status, Status::Running);
+    assert_eq!(deserialized.priority, Priority::High);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum LargeEnum {
+    V0 = 0,
+    V1 = 1,
+    V2 = 2,
+    V3 = 3,
+    V4 = 4,
+    V5 = 5,
+    V6 = 6,
+    V7 = 7,
+    V8 = 8,
+    V9 = 9,
+    V10 = 10,
+    V11 = 11,
+    V12 = 12,
+    V13 = 13,
+    V14 = 14,
+    V15 = 15,
+    V16 = 16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+struct PacketWithLargeEnum {
+    #[bits(3)]
+    prefix: u8,
+    #[bits()] // Auto-sized to LargeEnum::__BEBYTES_MIN_BITS (5 bits)
+    large: LargeEnum,
+}
+
+#[test]
+fn test_large_enum_auto_bits() {
+    // Test that 17 variants need 5 bits (2^4 = 16 < 17 <= 2^5 = 32)
+    assert_eq!(LargeEnum::__BEBYTES_MIN_BITS, 5);
+
+    let packet = PacketWithLargeEnum {
+        prefix: 0b101,
+        large: LargeEnum::V16,
+    };
+
+    let be_bytes = packet.to_be_bytes();
+    assert_eq!(be_bytes.len(), 1); // 3+5 = 8 bits = 1 byte
+
+    // Verify bit layout: prefix(3) | large(5)
+    // 101 | 10000 = 0b10110000 = 176
+    assert_eq!(be_bytes[0], 0b10110000);
+
+    let (deserialized, _) = PacketWithLargeEnum::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(deserialized.prefix, 0b101);
+    assert_eq!(deserialized.large, LargeEnum::V16);
+}

--- a/bebytes/tests/test_auto_enum_bits_comprehensive.rs
+++ b/bebytes/tests/test_auto_enum_bits_comprehensive.rs
@@ -1,0 +1,228 @@
+use bebytes::BeBytes;
+
+// Test edge cases for enum bit width calculation
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum SingleVariant {
+    Only = 0,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum TwoVariants {
+    First = 0,
+    Second = 1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum ExactPowerOfTwo {
+    V0 = 0,
+    V1 = 1,
+    V2 = 2,
+    V3 = 3,
+    V4 = 4,
+    V5 = 5,
+    V6 = 6,
+    V7 = 7,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum JustOverPowerOfTwo {
+    V0 = 0,
+    V1 = 1,
+    V2 = 2,
+    V3 = 3,
+    V4 = 4,
+    V5 = 5,
+    V6 = 6,
+    V7 = 7,
+    V8 = 8,
+}
+
+#[test]
+fn test_minimum_bits_calculation() {
+    // 1 variant needs 0 bits (but we use 1 bit minimum)
+    assert_eq!(SingleVariant::__BEBYTES_MIN_BITS, 1);
+
+    // 2 variants need 1 bit
+    assert_eq!(TwoVariants::__BEBYTES_MIN_BITS, 1);
+
+    // 8 variants need exactly 3 bits
+    assert_eq!(ExactPowerOfTwo::__BEBYTES_MIN_BITS, 3);
+
+    // 9 variants need 4 bits
+    assert_eq!(JustOverPowerOfTwo::__BEBYTES_MIN_BITS, 4);
+}
+
+// Test multiple auto-sized enums in a single struct
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+struct MultiAutoEnums {
+    #[bits()]
+    single: SingleVariant,
+    #[bits()]
+    two: TwoVariants,
+    #[bits()]
+    eight: ExactPowerOfTwo,
+    #[bits()]
+    nine: JustOverPowerOfTwo,
+}
+
+#[test]
+fn test_multiple_auto_enums() {
+    let packet = MultiAutoEnums {
+        single: SingleVariant::Only,
+        two: TwoVariants::Second,
+        eight: ExactPowerOfTwo::V7,
+        nine: JustOverPowerOfTwo::V8,
+    };
+
+    // Total bits: 1 + 1 + 3 + 4 = 9 bits = 2 bytes
+    let be_bytes = packet.to_be_bytes();
+    println!(
+        "Bytes generated: {:?}, length: {}",
+        be_bytes,
+        be_bytes.len()
+    );
+    println!("Expected total bits: 1 + 1 + 3 + 4 = 9");
+    assert_eq!(be_bytes.len(), 2);
+
+    let (deserialized, bytes_read) = MultiAutoEnums::try_from_be_bytes(&be_bytes).unwrap();
+    println!("Bytes read: {}", bytes_read);
+    // With 9 bits total, we need to read 2 bytes (ceiling of 9/8)
+    assert_eq!(bytes_read, 2);
+    assert_eq!(deserialized.single, SingleVariant::Only);
+    assert_eq!(deserialized.two, TwoVariants::Second);
+    assert_eq!(deserialized.eight, ExactPowerOfTwo::V7);
+    assert_eq!(deserialized.nine, JustOverPowerOfTwo::V8);
+}
+
+// Test auto-sized enums mixed with explicit-sized fields
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+struct MixedBitFields {
+    #[bits(5)]
+    explicit_u8: u8,
+    #[bits()]
+    auto_enum: TwoVariants,
+    #[bits(2)]
+    another_explicit: u8,
+    // Total: 5 + 1 + 2 = 8 bits
+}
+
+#[test]
+fn test_mixed_auto_and_explicit_bits() {
+    let packet = MixedBitFields {
+        explicit_u8: 0b11010,
+        auto_enum: TwoVariants::First,
+        another_explicit: 0b11,
+    };
+
+    let be_bytes = packet.to_be_bytes();
+    assert_eq!(be_bytes.len(), 1);
+
+    // Big-endian bit layout: explicit_u8(5) | auto_enum(1) | another_explicit(2)
+    // 11010 | 0 | 11 = 0b11010011 = 211
+    assert_eq!(be_bytes[0], 0b11010011);
+
+    let (deserialized, _) = MixedBitFields::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(deserialized.explicit_u8, 0b11010);
+    assert_eq!(deserialized.auto_enum, TwoVariants::First);
+    assert_eq!(deserialized.another_explicit, 0b11);
+}
+
+// Test error handling for invalid discriminant values
+#[test]
+fn test_try_from_errors() {
+    // SingleVariant only has value 0
+    assert!(SingleVariant::try_from(1u8).is_err());
+
+    // TwoVariants has values 0-1
+    assert!(TwoVariants::try_from(2u8).is_err());
+    assert!(TwoVariants::try_from(255u8).is_err());
+
+    // ExactPowerOfTwo has values 0-7
+    assert!(ExactPowerOfTwo::try_from(8u8).is_err());
+
+    // JustOverPowerOfTwo has values 0-8
+    assert!(JustOverPowerOfTwo::try_from(9u8).is_err());
+}
+
+// Test with non-contiguous discriminant values
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+#[repr(u8)]
+enum NonContiguous {
+    A = 0,
+    B = 2,
+    C = 5,
+    D = 7,
+}
+
+#[test]
+fn test_non_contiguous_enum() {
+    // Max discriminant is 7, which needs 3 bits
+    assert_eq!(NonContiguous::__BEBYTES_MIN_BITS, 3);
+
+    // Test TryFrom for valid values
+    assert_eq!(NonContiguous::try_from(0u8).unwrap(), NonContiguous::A);
+    assert_eq!(NonContiguous::try_from(2u8).unwrap(), NonContiguous::B);
+    assert_eq!(NonContiguous::try_from(5u8).unwrap(), NonContiguous::C);
+    assert_eq!(NonContiguous::try_from(7u8).unwrap(), NonContiguous::D);
+
+    // Test TryFrom for invalid values (gaps in discriminants)
+    assert!(NonContiguous::try_from(1u8).is_err());
+    assert!(NonContiguous::try_from(3u8).is_err());
+    assert!(NonContiguous::try_from(4u8).is_err());
+    assert!(NonContiguous::try_from(6u8).is_err());
+}
+
+// Test auto-sized enum at the end of multi-byte bit fields
+#[derive(Debug, Clone, Copy, PartialEq, BeBytes)]
+struct CrossByteBoundary {
+    #[bits(7)]
+    large_field: u8,
+    #[bits()] // 3 bits for ExactPowerOfTwo
+    enum_field: ExactPowerOfTwo,
+    #[bits(6)]
+    trailing: u8,
+    // Total: 7 + 3 + 6 = 16 bits = 2 bytes
+}
+
+#[test]
+fn test_cross_byte_boundary() {
+    let packet = CrossByteBoundary {
+        large_field: 0b1111111,          // All bits set
+        enum_field: ExactPowerOfTwo::V5, // Value 5 = 0b101
+        trailing: 0b101010,
+    };
+
+    let be_bytes = packet.to_be_bytes();
+    assert_eq!(be_bytes.len(), 2);
+
+    let (deserialized, _) = CrossByteBoundary::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(deserialized.large_field, 0b1111111);
+    assert_eq!(deserialized.enum_field, ExactPowerOfTwo::V5);
+    assert_eq!(deserialized.trailing, 0b101010);
+}
+
+// Test little-endian behavior with auto-sized enums
+#[test]
+fn test_little_endian_auto_enums() {
+    let packet = MixedBitFields {
+        explicit_u8: 0b10101,
+        auto_enum: TwoVariants::Second,
+        another_explicit: 0b10,
+    };
+
+    let le_bytes = packet.to_le_bytes();
+    assert_eq!(le_bytes.len(), 1);
+
+    // Little-endian bit layout within byte: another_explicit(2) | auto_enum(1) | explicit_u8(5)
+    // 10 | 1 | 10101 = 0b10110101 = 181
+    assert_eq!(le_bytes[0], 0b10110101);
+
+    let (deserialized, _) = MixedBitFields::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(deserialized.explicit_u8, 0b10101);
+    assert_eq!(deserialized.auto_enum, TwoVariants::Second);
+    assert_eq!(deserialized.another_explicit, 0b10);
+}

--- a/bebytes/tests/test_bare_bits_attr.rs
+++ b/bebytes/tests/test_bare_bits_attr.rs
@@ -1,0 +1,36 @@
+use bebytes::BeBytes;
+
+#[derive(BeBytes, Debug, PartialEq, Clone, Copy)]
+enum TestEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+    D = 3,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct TestStruct {
+    #[bits(4)]
+    field1: u8,
+    #[bits()]
+    // Testing empty parentheses for auto-sizing - should use TestEnum::__BEBYTES_MIN_BITS (2 bits)
+    field2: TestEnum,
+    #[bits(2)]
+    field3: u8,
+}
+
+#[test]
+fn test_bare_bits_attribute() {
+    let original = TestStruct {
+        field1: 0x0F,
+        field2: TestEnum::C,
+        field3: 0x03,
+    };
+
+    let bytes = original.to_be_bytes();
+    println!("Bytes: {:?}", bytes);
+    
+    // Test roundtrip: deserialize and verify equality
+    let (deserialized, _) = TestStruct::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(original, deserialized);
+}

--- a/bebytes/tests/test_enum_bits.rs
+++ b/bebytes/tests/test_enum_bits.rs
@@ -1,0 +1,297 @@
+use bebytes::BeBytes;
+
+// Simple test enum with a few variants
+#[derive(BeBytes, Debug, PartialEq, Clone, Copy)]
+pub enum TestStatus {
+    Idle = 0,
+    Running = 1,
+    Paused = 2,
+    Stopped = 3,
+    ErrorState = 4,
+}
+
+// Another enum to test different value ranges
+#[derive(BeBytes, Debug, PartialEq, Clone, Copy)]
+pub enum Priority {
+    Low = 0,
+    Normal = 1,
+    High = 2,
+    Critical = 3,
+}
+
+// Test struct using integer bit fields to represent enum values
+#[derive(BeBytes, Debug, PartialEq)]
+pub struct StatusPacket {
+    #[bits(3)] // 3 bits for status (0-4)
+    status_value: u8,
+    #[bits(2)] // 2 bits for priority (0-3)
+    priority_value: u8,
+    #[bits(3)] // Fill remaining bits to complete the byte
+    reserved: u8,
+}
+
+impl StatusPacket {
+    pub fn new_with_enums(status: TestStatus, priority: Priority, reserved: u8) -> Self {
+        Self {
+            status_value: status as u8,
+            priority_value: priority as u8,
+            reserved,
+        }
+    }
+
+    pub fn status(&self) -> TestStatus {
+        match self.status_value {
+            0 => TestStatus::Idle,
+            1 => TestStatus::Running,
+            2 => TestStatus::Paused,
+            3 => TestStatus::Stopped,
+            4 => TestStatus::ErrorState,
+            _ => TestStatus::Idle, // Default
+        }
+    }
+
+    pub fn priority(&self) -> Priority {
+        match self.priority_value {
+            0 => Priority::Low,
+            1 => Priority::Normal,
+            2 => Priority::High,
+            3 => Priority::Critical,
+            _ => Priority::Low, // Default
+        }
+    }
+}
+
+// Test struct with enum as regular field
+#[derive(BeBytes, Debug, PartialEq)]
+pub struct SimpleEnumPacket {
+    header: u8,
+    status: TestStatus,
+    priority: Priority,
+    footer: u16,
+}
+
+// Test struct demonstrating enum size calculation
+#[derive(BeBytes, Debug, PartialEq)]
+pub struct MixedPacket {
+    #[bits(1)]
+    enabled: u8,
+    #[bits(3)] // status bits
+    status_bits: u8,
+    #[bits(2)] // priority bits
+    priority_bits: u8,
+    #[bits(2)] // padding
+    padding: u8,
+    payload: u16,
+}
+
+impl MixedPacket {
+    pub fn new_with_enums(
+        enabled: u8,
+        status: TestStatus,
+        priority: Priority,
+        padding: u8,
+        payload: u16,
+    ) -> Self {
+        Self {
+            enabled,
+            status_bits: status as u8,
+            priority_bits: priority as u8,
+            padding,
+            payload,
+        }
+    }
+
+    pub fn status(&self) -> TestStatus {
+        match self.status_bits {
+            0 => TestStatus::Idle,
+            1 => TestStatus::Running,
+            2 => TestStatus::Paused,
+            3 => TestStatus::Stopped,
+            4 => TestStatus::ErrorState,
+            _ => TestStatus::Idle,
+        }
+    }
+
+    pub fn priority(&self) -> Priority {
+        match self.priority_bits {
+            0 => Priority::Low,
+            1 => Priority::Normal,
+            2 => Priority::High,
+            3 => Priority::Critical,
+            _ => Priority::Low,
+        }
+    }
+}
+
+#[test]
+fn test_enum_bits_basic() {
+    // Test using helper constructor
+    let packet = StatusPacket::new_with_enums(TestStatus::Running, Priority::High, 0);
+
+    // Test big-endian
+    let be_bytes = packet.to_be_bytes();
+    println!("BE bytes: {:?}", be_bytes);
+    for byte in &be_bytes {
+        print!("{:08b} ", byte);
+    }
+    println!();
+
+    let (decoded, len) = StatusPacket::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(decoded.status_value, TestStatus::Running as u8);
+    assert_eq!(decoded.priority_value, Priority::High as u8);
+    assert_eq!(decoded.reserved, 0);
+    assert_eq!(len, be_bytes.len());
+
+    // Test using accessor methods
+    assert_eq!(decoded.status(), TestStatus::Running);
+    assert_eq!(decoded.priority(), Priority::High);
+
+    // Test little-endian
+    let le_bytes = packet.to_le_bytes();
+    println!("LE bytes: {:?}", le_bytes);
+
+    let (decoded_le, len_le) = StatusPacket::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(decoded_le.status(), TestStatus::Running);
+    assert_eq!(decoded_le.priority(), Priority::High);
+    assert_eq!(len_le, le_bytes.len());
+}
+
+#[test]
+fn test_enum_bits_all_variants() {
+    // Test all status variants
+    let statuses = [
+        TestStatus::Idle,
+        TestStatus::Running,
+        TestStatus::Paused,
+        TestStatus::Stopped,
+        TestStatus::ErrorState,
+    ];
+
+    let priorities = [
+        Priority::Low,
+        Priority::Normal,
+        Priority::High,
+        Priority::Critical,
+    ];
+
+    for status in &statuses {
+        for priority in &priorities {
+            let packet = StatusPacket::new_with_enums(*status, *priority, 0);
+
+            // Test round trip big-endian
+            let be_bytes = packet.to_be_bytes();
+            let (decoded, _) = StatusPacket::try_from_be_bytes(&be_bytes).unwrap();
+            assert_eq!(decoded.status(), *status);
+            assert_eq!(decoded.priority(), *priority);
+
+            // Test round trip little-endian
+            let le_bytes = packet.to_le_bytes();
+            let (decoded_le, _) = StatusPacket::try_from_le_bytes(&le_bytes).unwrap();
+            assert_eq!(decoded_le.status(), *status);
+            assert_eq!(decoded_le.priority(), *priority);
+        }
+    }
+}
+
+#[test]
+fn test_simple_enum_packet() {
+    let packet = SimpleEnumPacket {
+        header: 0xFF,
+        status: TestStatus::Paused,
+        priority: Priority::Normal,
+        footer: 0x1234,
+    };
+
+    // Test big-endian
+    let be_bytes = packet.to_be_bytes();
+    println!("Simple enum packet BE bytes: {:?}", be_bytes);
+
+    let (decoded, len) = SimpleEnumPacket::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(decoded, packet);
+    assert_eq!(len, be_bytes.len());
+
+    // Test little-endian
+    let le_bytes = packet.to_le_bytes();
+    let (decoded_le, _) = SimpleEnumPacket::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(decoded_le, packet);
+}
+
+#[test]
+fn test_mixed_packet() {
+    let packet = MixedPacket::new_with_enums(1, TestStatus::Paused, Priority::Normal, 0, 0x1234);
+
+    // Test big-endian
+    let be_bytes = packet.to_be_bytes();
+    println!("Mixed packet BE bytes: {:?}", be_bytes);
+
+    let (decoded, len) = MixedPacket::try_from_be_bytes(&be_bytes).unwrap();
+    assert_eq!(decoded.enabled, 1);
+    assert_eq!(decoded.status(), TestStatus::Paused);
+    assert_eq!(decoded.priority(), Priority::Normal);
+    assert_eq!(decoded.payload, 0x1234);
+    assert_eq!(len, be_bytes.len());
+
+    // Test little-endian
+    let le_bytes = packet.to_le_bytes();
+    println!("Mixed packet LE bytes: {:?}", le_bytes);
+
+    let (decoded_le, len_le) = MixedPacket::try_from_le_bytes(&le_bytes).unwrap();
+    assert_eq!(decoded_le.enabled, 1);
+    assert_eq!(decoded_le.status(), TestStatus::Paused);
+    assert_eq!(decoded_le.priority(), Priority::Normal);
+    assert_eq!(decoded_le.payload, 0x1234);
+    assert_eq!(len_le, le_bytes.len());
+}
+
+#[test]
+fn test_enum_constructor() {
+    // Test direct construction with new()
+    let packet = StatusPacket::new(TestStatus::ErrorState as u8, Priority::Critical as u8, 0);
+    assert_eq!(packet.status_value, TestStatus::ErrorState as u8);
+    assert_eq!(packet.priority_value, Priority::Critical as u8);
+    assert_eq!(packet.reserved, 0);
+
+    // Test using accessor methods
+    assert_eq!(packet.status(), TestStatus::ErrorState);
+    assert_eq!(packet.priority(), Priority::Critical);
+
+    let mixed = MixedPacket::new(1, TestStatus::Running as u8, Priority::Low as u8, 0, 0xABCD);
+    assert_eq!(mixed.enabled, 1);
+    assert_eq!(mixed.status(), TestStatus::Running);
+    assert_eq!(mixed.priority(), Priority::Low);
+    assert_eq!(mixed.padding, 0);
+    assert_eq!(mixed.payload, 0xABCD);
+}
+
+#[test]
+fn test_endianness_difference() {
+    let packet =
+        MixedPacket::new_with_enums(1, TestStatus::ErrorState, Priority::Critical, 0, 0x1234);
+
+    let be_bytes = packet.to_be_bytes();
+    let le_bytes = packet.to_le_bytes();
+
+    // The byte representations should be different for multi-byte values
+    assert_ne!(be_bytes, le_bytes);
+
+    // But decoding with the correct endianness should yield the same result
+    let (from_be, _) = MixedPacket::try_from_be_bytes(&be_bytes).unwrap();
+    let (from_le, _) = MixedPacket::try_from_le_bytes(&le_bytes).unwrap();
+
+    assert_eq!(from_be.enabled, packet.enabled);
+    assert_eq!(from_be.status(), packet.status());
+    assert_eq!(from_be.priority(), packet.priority());
+    assert_eq!(from_be.payload, packet.payload);
+
+    assert_eq!(from_le.enabled, packet.enabled);
+    assert_eq!(from_le.status(), packet.status());
+    assert_eq!(from_le.priority(), packet.priority());
+    assert_eq!(from_le.payload, packet.payload);
+}
+
+#[test]
+fn test_enum_min_bits() {
+    // Test that enums expose their minimum bit requirements
+    assert_eq!(TestStatus::__BEBYTES_MIN_BITS, 3); // Need 3 bits for values 0-4
+    assert_eq!(Priority::__BEBYTES_MIN_BITS, 2); // Need 2 bits for values 0-3
+}

--- a/bebytes/tests/test_enum_flags.rs
+++ b/bebytes/tests/test_enum_flags.rs
@@ -1,0 +1,149 @@
+use bebytes::BeBytes;
+
+#[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
+#[bebytes(flags)]
+#[repr(u8)]
+enum Permissions {
+    Read = 1,
+    Write = 2,
+    Execute = 4,
+}
+
+#[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
+#[bebytes(flags)]
+#[repr(u8)]
+enum FileAttributes {
+    Hidden = 1,
+    System = 2,
+    ReadOnly = 4,
+    Archive = 8,
+    Directory = 16,
+    Compressed = 32,
+    Encrypted = 64,
+}
+
+#[test]
+fn test_bitwise_or() {
+    let read_write = Permissions::Read | Permissions::Write;
+    assert_eq!(read_write, 3);
+
+    let all_perms = Permissions::Read | Permissions::Write | Permissions::Execute;
+    assert_eq!(all_perms, 7);
+}
+
+#[test]
+fn test_bitwise_and() {
+    let read_write = Permissions::Read | Permissions::Write;
+
+    // Check if has Read permission
+    assert_eq!(read_write & Permissions::Read as u8, 1);
+
+    // Check if has Execute permission
+    assert_eq!(read_write & Permissions::Execute as u8, 0);
+}
+
+#[test]
+fn test_bitwise_xor() {
+    let perms = Permissions::Read | Permissions::Write;
+
+    // Toggle Write permission
+    let toggled = perms ^ Permissions::Write as u8;
+    assert_eq!(toggled, 1); // Only Read remains
+
+    // Toggle Write again
+    let toggled_back = toggled ^ Permissions::Write as u8;
+    assert_eq!(toggled_back, 3); // Read and Write
+}
+
+#[test]
+fn test_not_operator() {
+    let perm = Permissions::Read;
+    let inverted = !perm;
+    assert_eq!(inverted & 0b111, 0b110); // Within 3-bit range, Read bit is off
+}
+
+#[test]
+fn test_contains_method() {
+    let perms = Permissions::Read | Permissions::Execute;
+
+    assert!(Permissions::Read.contains(Permissions::Read));
+    assert!(!Permissions::Read.contains(Permissions::Write));
+
+    // Test with combined flags
+    let read_u8 = perms;
+    let read_perm = Permissions::Read;
+    assert_eq!((read_u8 & read_perm as u8), read_perm as u8);
+}
+
+#[test]
+fn test_from_bits() {
+    // Valid combination
+    assert_eq!(Permissions::from_bits(7), Some(7)); // Read | Write | Execute
+    assert_eq!(Permissions::from_bits(3), Some(3)); // Read | Write
+
+    // Invalid bits (8 is not a valid permission)
+    assert_eq!(Permissions::from_bits(8), None);
+    assert_eq!(Permissions::from_bits(15), None); // 15 = 1111, includes invalid bit 8
+}
+
+#[test]
+fn test_serialization_with_flags() {
+    #[derive(BeBytes, Debug, PartialEq)]
+    struct FileInfo {
+        #[bits(8)]
+        flags: u8, // Store combined permissions
+        size: u32,
+    }
+
+    let info = FileInfo {
+        flags: Permissions::Read | Permissions::Execute,
+        size: 1024,
+    };
+
+    let bytes = info.to_be_bytes();
+    assert_eq!(bytes.len(), 5); // 1 byte for flags + 4 bytes for u32
+    assert_eq!(bytes[0], 5); // Read (1) | Execute (4) = 5
+
+    let (decoded, _) = FileInfo::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded.flags, 5);
+    assert_eq!(decoded.size, 1024);
+}
+
+#[test]
+fn test_large_flag_enum() {
+    let attrs = FileAttributes::Hidden | FileAttributes::ReadOnly | FileAttributes::Compressed;
+    assert_eq!(attrs, 1 | 4 | 32);
+    assert_eq!(attrs, 37);
+
+    // Test from_bits with large values
+    assert_eq!(FileAttributes::from_bits(127), Some(127)); // All 7 flags
+    assert_eq!(FileAttributes::from_bits(128), None); // Invalid bit
+}
+
+#[test]
+fn test_flag_enum_in_struct() {
+    #[derive(BeBytes, Debug, PartialEq)]
+    struct FileMetadata {
+        #[bits(7)]
+        attributes: u8, // Store FileAttributes flags
+        #[bits(1)]
+        is_modified: u8,
+        name_length: u8,
+        #[FromField(name_length)]
+        name: Vec<u8>,
+    }
+
+    let meta = FileMetadata {
+        attributes: FileAttributes::Hidden | FileAttributes::Archive,
+        is_modified: 1,
+        name_length: 8,
+        name: b"test.txt".to_vec(),
+    };
+
+    let bytes = meta.to_be_bytes();
+    let (decoded, _) = FileMetadata::try_from_be_bytes(&bytes).unwrap();
+
+    assert_eq!(decoded.attributes, 9); // Hidden (1) | Archive (8)
+    assert_eq!(decoded.is_modified, 1);
+    assert_eq!(decoded.name, b"test.txt");
+}

--- a/bebytes/tests/ui/invalid_flag_enum.rs
+++ b/bebytes/tests/ui/invalid_flag_enum.rs
@@ -1,0 +1,14 @@
+use bebytes::BeBytes;
+
+// This should fail because 3 is not a power of 2
+#[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
+#[bebytes(flags)]
+#[repr(u8)]
+enum InvalidFlags {
+    Flag1 = 1,
+    Flag2 = 2,
+    Flag3 = 3, // Not a power of 2!
+    Flag4 = 4,
+}
+
+fn main() {}

--- a/bebytes/tests/ui/invalid_flag_enum.stderr
+++ b/bebytes/tests/ui/invalid_flag_enum.stderr
@@ -1,0 +1,5 @@
+error: Flag enum variant 'Flag3' has value 3 which is not a power of 2
+  --> tests/ui/invalid_flag_enum.rs:10:5
+   |
+10 |     Flag3 = 3, // Not a power of 2!
+   |     ^^^^^

--- a/bebytes/tests/ui/zero_value_flag_enum.rs
+++ b/bebytes/tests/ui/zero_value_flag_enum.rs
@@ -1,0 +1,17 @@
+use bebytes::BeBytes;
+
+// This should succeed - zero is allowed in flag enums
+#[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
+#[bebytes(flags)]
+#[repr(u8)]
+enum FlagsWithZero {
+    None = 0,    // Zero is allowed
+    Flag1 = 1,
+    Flag2 = 2,
+    Flag4 = 4,
+}
+
+fn main() {
+    // This should compile fine
+    let _flags = FlagsWithZero::Flag1 | FlagsWithZero::Flag2;
+}

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/bebytes_derive/README.md
+++ b/bebytes_derive/README.md
@@ -150,6 +150,37 @@ pub enum DummyEnum {
 }
 ```
 
+### Enum Bit Packing (New in 1.2.0)
+
+Enums can now be used with the `#[bits()]` attribute for automatic bit-width calculation. When you use `#[bits()]` (with empty parentheses) on an enum field, the macro automatically calculates the minimum number of bits needed to represent all enum variants.
+
+```rust
+#[derive(BeBytes, Debug, PartialEq)]
+#[repr(u8)]
+enum Status {
+    Idle = 0,
+    Running = 1,
+    Paused = 2,
+    Stopped = 3,
+}
+
+#[derive(BeBytes)]
+struct PacketHeader {
+    #[bits(4)]
+    version: u8,
+    #[bits()]  // Automatically uses 2 bits (minimum needed for 4 variants)
+    status: Status,
+    #[bits(2)]
+    flags: u8,
+}
+```
+
+The macro:
+- Calculates minimum bits as `ceil(log2(max_discriminant + 1))`
+- Generates a `__BEBYTES_MIN_BITS` constant for each enum
+- Implements `TryFrom<u8>` for safe conversion from discriminant values
+- Handles byte-spanning fields automatically
+
 ## Options
 
 Options are supported, as long as the internal type is a primitive

--- a/bebytes_derive/src/attrs.rs
+++ b/bebytes_derive/src/attrs.rs
@@ -5,11 +5,11 @@ use std::vec::Vec;
 use alloc::vec::Vec;
 
 pub fn parse_attributes(
-    attributes: Vec<syn::Attribute>,
+    attributes: &[syn::Attribute],
     bits_attribute_present: &mut bool,
     errors: &mut Vec<proc_macro2::TokenStream>,
 ) -> (Option<usize>, Option<proc_macro2::Ident>) {
-    match crate::functional::functional_attrs::parse_attributes_functional(&attributes) {
+    match crate::functional::functional_attrs::parse_attributes_functional(attributes) {
         Ok(attr_data) => {
             *bits_attribute_present = attr_data.is_bits_attribute;
             (attr_data.size, attr_data.field)

--- a/bebytes_derive/src/bit_validation.rs
+++ b/bebytes_derive/src/bit_validation.rs
@@ -4,20 +4,48 @@ use proc_macro2::TokenStream;
 
 pub fn validate_byte_completeness(fields: &syn::FieldsNamed) -> Result<(), TokenStream> {
     let mut total_bits = 0;
+    let mut has_auto_sized = false;
 
     for field in &fields.named {
         for attr in &field.attrs {
             if attr.path().is_ident("bits") {
                 // Parse #[bits(N)] where N is the size
-                match attr.parse_args::<syn::LitInt>() {
-                    Ok(lit) => match lit.base10_parse::<usize>() {
-                        Ok(n) => total_bits += n,
-                        Err(e) => return Err(e.to_compile_error()),
-                    },
-                    Err(e) => return Err(e.to_compile_error()),
+                // For validation, we need to know the actual size
+                // Auto-sized fields (#[bits()]) will be handled later
+                match &attr.meta {
+                    syn::Meta::List(list) => {
+                        if list.tokens.is_empty() {
+                            // #[bits()] - auto-sized, skip validation for now
+                            // The actual validation will happen during code generation
+                            has_auto_sized = true;
+                            continue;
+                        }
+
+                        // Try to parse as integer
+                        match attr.parse_args::<syn::LitInt>() {
+                            Ok(literal) => match literal.base10_parse::<usize>() {
+                                Ok(n) => total_bits += n,
+                                Err(e) => return Err(e.to_compile_error()),
+                            },
+                            Err(e) => return Err(e.to_compile_error()),
+                        }
+                    }
+                    _ => {
+                        // This shouldn't happen due to Rust's validation
+                        return Err(
+                            syn::Error::new_spanned(attr, "Invalid bits attribute format")
+                                .to_compile_error(),
+                        );
+                    }
                 }
             }
         }
+    }
+
+    // If there are auto-sized fields, we can't validate at compile time
+    // The validation will happen during code generation
+    if has_auto_sized {
+        return Ok(());
     }
 
     // Check if bits complete a full byte

--- a/bebytes_derive/src/enums.rs
+++ b/bebytes_derive/src/enums.rs
@@ -6,17 +6,33 @@ use std::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+// Type alias for the complex return type
+type EnumHandleResult = (
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
+    usize,
+    Vec<proc_macro2::TokenStream>,
+    Vec<(syn::Ident, u8)>,
+);
+
 pub fn handle_enum(
     mut errors: Vec<proc_macro2::TokenStream>,
     data_enum: syn::DataEnum,
-) -> (Vec<proc_macro2::TokenStream>, Vec<proc_macro2::TokenStream>) {
+) -> EnumHandleResult {
     let variants = data_enum.variants;
     let values = variants
         .iter()
         .enumerate()
         .map(|(index, variant)| {
             let ident = &variant.ident;
-            let mut assigned_value = index as u8;
+            let mut assigned_value = u8::try_from(index).unwrap_or_else(|_| {
+                let error = syn::Error::new(
+                    ident.span(),
+                    format!("Enum variant index {} exceeds u8 range", index),
+                );
+                errors.push(error.to_compile_error());
+                0
+            });
             if let Some((_, syn::Expr::Lit(expr_lit))) = &variant.discriminant {
                 if let syn::Lit::Int(token) = &expr_lit.lit {
                     assigned_value = token.base10_parse().unwrap_or_else(|_e| {
@@ -25,8 +41,8 @@ pub fn handle_enum(
                         0
                     });
                 }
-            };
-            (ident, assigned_value)
+            }
+            (ident.clone(), assigned_value)
         })
         .collect::<Vec<_>>();
 
@@ -48,6 +64,39 @@ pub fn handle_enum(
         })
         .collect::<Vec<_>>();
 
+    // Calculate minimum bits needed for this enum
+    let max_discriminant = values.iter().map(|(_, value)| *value).max().unwrap_or(0);
+
+    // Calculate minimum bits: ceil(log2(max_discriminant + 1))
+    let min_bits = if max_discriminant == 0 {
+        1 // Even a single variant needs at least 1 bit
+    } else {
+        // Find the position of the highest set bit
+        let mut bits = 0;
+        let mut val = max_discriminant;
+        while val > 0 {
+            bits += 1;
+            val >>= 1;
+        }
+        bits
+    };
+
+    // Generate TryFrom<u8> arms for auto-sized bit fields
+    let try_from_arms = values
+        .iter()
+        .map(|(ident, assigned_value)| {
+            quote! {
+                #assigned_value => Ok(Self::#ident),
+            }
+        })
+        .collect::<Vec<_>>();
+
     // For enums, the byte representation is the same for both endianness since we're just storing a single byte value
-    (from_bytes_arms, to_bytes_arms)
+    (
+        from_bytes_arms,
+        to_bytes_arms,
+        min_bits,
+        try_from_arms,
+        values,
+    )
 }

--- a/bebytes_derive/src/utils.rs
+++ b/bebytes_derive/src/utils.rs
@@ -61,9 +61,8 @@ pub fn solve_for_inner_type(input: &syn::TypePath, identifier: &str) -> Option<s
         _ => return None,
     };
 
-    let inner_type = match &args[0] {
-        syn::GenericArgument::Type(t) => t,
-        _ => return None,
+    let syn::GenericArgument::Type(inner_type) = &args[0] else {
+        return None;
     };
 
     Some(inner_type.clone())
@@ -87,8 +86,7 @@ pub fn is_supported_primitive_type(tp: &syn::TypePath) -> bool {
 
 pub(crate) fn is_copy(field_type: &syn::Type) -> bool {
     match field_type {
-        syn::Type::Never(_) => true, // ! is Copy
-        syn::Type::Infer(_) => true, // _ is considered Copy for inference
+        syn::Type::Never(_) | syn::Type::Infer(_) => true, // ! and _ are Copy
 
         syn::Type::Path(type_path) => {
             // Check if it's a known Copy primitive or standard library type
@@ -160,13 +158,13 @@ pub(crate) fn is_copy(field_type: &syn::Type) -> bool {
             type_reference.mutability.is_none()
         }
         // These are generally not Copy
-        syn::Type::BareFn(_) => false,
-        syn::Type::ImplTrait(_) => false,
-        syn::Type::Macro(_) => false,
-        syn::Type::Ptr(_) => false, // Raw pointers are Copy, but we're being conservative
-        syn::Type::Slice(_) => false, // Slices are not sized, so not Copy
-        syn::Type::TraitObject(_) => false,
-        syn::Type::Verbatim(_) => false,
+        syn::Type::BareFn(_)
+        | syn::Type::ImplTrait(_)
+        | syn::Type::Macro(_)
+        | syn::Type::Ptr(_) // Raw pointers are Copy, but we're being conservative
+        | syn::Type::Slice(_) // Slices are not sized, so not Copy
+        | syn::Type::TraitObject(_)
+        | syn::Type::Verbatim(_) => false,
         _ => false, // Conservative default for any other types
     }
 }


### PR DESCRIPTION
## Summary
- Add `#[bits()]` for automatic enum bit-width calculation
- Add `#[bebytes(flags)]` for flag-style enums with bitwise operations
- Add comprehensive test coverage and documentation
- Bump versions to 1.2.0

## Test plan
- [ ] Run `cargo test` to ensure all tests pass
- [ ] Run `cargo run --bin macro_test` to verify examples work
- [ ] Test both auto-sized enums and flag enums in practice
- [ ] Verify documentation is accurate and complete