### PR TITLE
feat: add enum discriminant validation to bebytes_derive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 expanded.rs
 .DS_Store
 CLAUDE.md
+.vscode/ltex.dictionary.en-US.txt

--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Produces `DummyEnum: [2]`
 
 ### Enum Bit Packing
 
-Enums can now be used with the `#[bits()]` attribute for automatic bit-width calculation. When you use `#[bits()]` (with empty parentheses) on an enum field, the macro automatically calculates the minimum number of bits needed to represent all enum variants.
+Enums can be used with the `#[bits()]` attribute for automatic bit-width calculation. When you use `#[bits()]` (with empty parentheses) on an enum field, the macro automatically calculates the minimum number of bits needed to represent all enum variants. While `#[repr(u8)]` is not strictly required, it is recommended as best practice:
 
 ```rust
 #[derive(BeBytes, Debug, PartialEq)]
-#[repr(u8)]
+#[repr(u8)]  // Recommended: ensures discriminants fit in u8 at compile time
 enum Status {
     Idle = 0,
     Running = 1,
@@ -251,6 +251,14 @@ struct MixedPacket {
 2. **Type Safety**: The compiler ensures enum values fit in the allocated bits
 3. **Flexibility**: Mix auto-sized enum fields with explicitly-sized integer fields
 4. **Efficiency**: Use exactly the bits needed, no more, no less
+5. **Safety**: Compile-time validation ensures all discriminants fit within u8 range (0-255)
+
+#### Note on `#[repr(u8)]`
+
+While BeBytes will work without `#[repr(u8)]`:
+- Without it: The macro validates at compile time that discriminants fit in u8 range
+- With it: The Rust compiler itself enforces the constraint, providing earlier error detection
+- **Recommendation**: Always use `#[repr(u8)]` for enums with BeBytes for clarity and safety
 
 ### Flag Enums
 

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/bebytes_derive/src/enums.rs
+++ b/bebytes_derive/src/enums.rs
@@ -13,6 +13,7 @@ type EnumHandleResult = (
     usize,
     Vec<proc_macro2::TokenStream>,
     Vec<(syn::Ident, u8)>,
+    Vec<proc_macro2::TokenStream>, // errors
 );
 
 pub fn handle_enum(
@@ -35,11 +36,29 @@ pub fn handle_enum(
             });
             if let Some((_, syn::Expr::Lit(expr_lit))) = &variant.discriminant {
                 if let syn::Lit::Int(token) = &expr_lit.lit {
-                    assigned_value = token.base10_parse().unwrap_or_else(|_e| {
-                        let error = syn::Error::new(token.span(), "Failed to parse token value");
+                    // First parse as usize to check the actual value
+                    let value: usize = token.base10_parse().unwrap_or_else(|_e| {
+                        let error = syn::Error::new(token.span(), "Failed to parse discriminant value");
                         errors.push(error.to_compile_error());
                         0
                     });
+                    
+                    // Check if value exceeds u8 range
+                    if value > 255 {
+                        let error = syn::Error::new(
+                            token.span(),
+                            format!(
+                                "Enum discriminant value {} exceeds u8 range (0-255). \
+                                Consider using #[repr(u8)] to make this constraint explicit, \
+                                or ensure all discriminants fit within u8 range.",
+                                value
+                            ),
+                        );
+                        errors.push(error.to_compile_error());
+                        assigned_value = 0; // Use 0 as fallback to continue compilation
+                    } else {
+                        assigned_value = value as u8;
+                    }
                 }
             }
             (ident.clone(), assigned_value)
@@ -98,5 +117,6 @@ pub fn handle_enum(
         min_bits,
         try_from_arms,
         values,
+        errors,
     )
 }

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -195,10 +195,18 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                 }
             });
 
-            let (from_be_bytes_arms, to_be_bytes_arms, min_bits, try_from_arms, discriminants) =
-                enums::handle_enum(errors, data_enum.clone());
-            let (from_le_bytes_arms, to_le_bytes_arms, _, _, _) =
+            let (from_be_bytes_arms, to_be_bytes_arms, min_bits, try_from_arms, discriminants, enum_errors) =
+                enums::handle_enum(Vec::new(), data_enum.clone());
+            let (from_le_bytes_arms, to_le_bytes_arms, _, _, _, _) =
                 enums::handle_enum(Vec::new(), data_enum);
+            
+            // If there are any errors from enum validation, return them
+            if !enum_errors.is_empty() {
+                return quote! {
+                    #(#enum_errors)*
+                }
+                .into();
+            }
 
             let expanded = quote! {
                 impl #name {


### PR DESCRIPTION
## Summary
Add compile-time validation for enum discriminants to ensure they fit within u8 range (0-255).

## Changes
- Add validation in `enums.rs` to check discriminant values
- Return errors from `handle_enum()` function and propagate them in `lib.rs`
- Emit helpful error messages when discriminants exceed u8::MAX

## Test Plan
- Added compile-time test `enum_discriminant_too_large.rs`
- Verified error message is clear and helpful
- All existing tests pass