### PR TITLE
chore: update bebytes to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use BeBytes Derive, add it as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-bebytes = "1.2.0"
+bebytes = "1.3.0"
 ```
 
 Then, import the BeBytes trait from the bebytes_derive crate and derive it for your struct:

--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -14,7 +14,7 @@ name = "macro_test"
 path = "./bin/macro_test.rs"
 
 [dependencies]
-bebytes_derive = "1.2.0"
+bebytes_derive = "1.3.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes/README.md
+++ b/bebytes/README.md
@@ -14,7 +14,7 @@ To use BeBytes, add it as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-bebytes = "1.2.0"
+bebytes = "1.3.0"
 ```
 
 Then, import the BeBytes trait from the bebytes crate and derive it for your struct:
@@ -271,7 +271,7 @@ BeBytes supports no_std environments through feature flags:
 
 ```toml
 [dependencies]
-bebytes = { version = "1.2.0", default-features = false }
+bebytes = { version = "1.3.0", default-features = false }
 ```
 
 By default, the `std` feature is enabled. Disable it for no_std support.

--- a/bebytes/tests/compile_time/zero_value_flag_enum.rs
+++ b/bebytes/tests/compile_time/zero_value_flag_enum.rs
@@ -13,5 +13,6 @@ enum FlagsWithZero {
 
 fn main() {
     // This should compile fine
-    let _flags = FlagsWithZero::Flag1 | FlagsWithZero::Flag2;
+    let flags = FlagsWithZero::Flag1 | FlagsWithZero::Flag2;
+    println!("Flags: {}", flags);
 }


### PR DESCRIPTION
## Summary
- Update bebytes to version 1.3.0 with bebytes_derive 1.3.0 dependency
- Update version references in documentation
- Fix unused variable warning in test file

## Changes
- Bump bebytes version from 1.2.0 to 1.3.0
- Update bebytes_derive dependency from 1.2.0 to 1.3.0
- Update version references in README files
- Fix unused variable in zero_value_flag_enum.rs test

## Test Plan
- [x] All existing tests pass
- [x] Cargo fmt passes
- [x] Cargo clippy passes
- [x] Version references updated consistently