### PR TITLE
chore: update bebytes to 1.4.0 with bebytes_derive 1.4.0 dependency

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -18,7 +18,7 @@ name = "performance_benchmark"
 path = "./bin/performance_benchmark.rs"
 
 [dependencies]
-bebytes_derive = "1.3.0"
+bebytes_derive = "1.4.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }


### PR DESCRIPTION
## Summary
- Update bebytes_derive dependency from 1.3.0 to 1.4.0
- Bump bebytes version from 1.3.0 to 1.4.0
- All tests pass with performance-optimized bebytes_derive

## Test plan
- [x] All existing tests pass
- [x] Version dependencies updated correctly
- [x] Performance optimizations from bebytes_derive 1.4.0 are available