### PR TITLE
feat: add nested field access support for FromField attribute

### DIFF
--- a/bebytes/README.md
+++ b/bebytes/README.md
@@ -240,6 +240,43 @@ struct DynamicVector {
 }
 ```
 
+### 3.1 Nested Field Access
+
+You can also reference fields in nested structures using dot notation:
+
+```rust
+#[derive(BeBytes, Clone)]
+struct Header {
+    version: u8,
+    count: u16,
+}
+
+#[derive(BeBytes)]
+struct Packet {
+    header: Header,
+    #[FromField(header.count)]
+    items: Vec<Item>,  // Will read 'header.count' items
+}
+
+// Even deeply nested fields are supported:
+#[derive(BeBytes, Clone)]
+struct ComplexHeader {
+    meta: MetaInfo,
+}
+
+#[derive(BeBytes, Clone)]
+struct MetaInfo {
+    item_count: u32,
+}
+
+#[derive(BeBytes)]
+struct ComplexPacket {
+    header: ComplexHeader,
+    #[FromField(header.meta.item_count)]
+    items: Vec<Item>,  // Will read 'header.meta.item_count' items
+}
+```
+
 ### 4. Vectors of Custom Types
 
 BeBytes supports vectors containing custom types that implement the `BeBytes` trait:

--- a/bebytes/tests/nested_field_test.rs
+++ b/bebytes/tests/nested_field_test.rs
@@ -1,0 +1,148 @@
+use bebytes::BeBytes;
+
+#[derive(BeBytes, Debug, PartialEq, Clone)]
+struct DnsHeader {
+    #[bits(16)]
+    transaction_id: u16,
+    #[bits(1)]
+    qr: u8,
+    #[bits(4)]
+    opcode: u8,
+    #[bits(1)]
+    aa: u8,
+    #[bits(1)]
+    tc: u8,
+    #[bits(1)]
+    rd: u8,
+    #[bits(1)]
+    ra: u8,
+    #[bits(3)]
+    z: u8,
+    #[bits(4)]
+    rcode: u8,
+    #[bits(16)]
+    qdcount: u16,
+    #[bits(16)]
+    ancount: u16,
+    #[bits(16)]
+    nscount: u16,
+    #[bits(16)]
+    arcount: u16,
+}
+
+#[derive(BeBytes, Debug, PartialEq, Clone)]
+struct DnsQuestion {
+    name: u8, // Simplified for test
+    qtype: u16,
+    qclass: u16,
+}
+
+#[derive(BeBytes, Debug, PartialEq, Clone)]
+struct DnsPacket {
+    header: DnsHeader,
+    #[FromField(header.qdcount)]
+    questions: Vec<DnsQuestion>,
+    #[FromField(header.ancount)]
+    answers: Vec<DnsQuestion>, // Reusing DnsQuestion for simplicity
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nested_field_access() {
+        let packet = DnsPacket {
+            header: DnsHeader {
+                transaction_id: 0x1234,
+                qr: 0,
+                opcode: 0,
+                aa: 0,
+                tc: 0,
+                rd: 1,
+                ra: 0,
+                z: 0,
+                rcode: 0,
+                qdcount: 2,
+                ancount: 1,
+                nscount: 0,
+                arcount: 0,
+            },
+            questions: vec![
+                DnsQuestion {
+                    name: 3,
+                    qtype: 1,
+                    qclass: 1,
+                },
+                DnsQuestion {
+                    name: 4,
+                    qtype: 1,
+                    qclass: 1,
+                },
+            ],
+            answers: vec![DnsQuestion {
+                name: 5,
+                qtype: 1,
+                qclass: 1,
+            }],
+        };
+
+        // Serialize
+        let bytes = packet.to_be_bytes();
+
+        // Deserialize
+        let (deserialized, _) = DnsPacket::try_from_be_bytes(&bytes).unwrap();
+
+        // Verify
+        assert_eq!(packet, deserialized);
+        assert_eq!(deserialized.questions.len(), 2);
+        assert_eq!(deserialized.answers.len(), 1);
+    }
+
+    #[test]
+    fn test_deeply_nested_field_access() {
+        #[derive(BeBytes, Debug, PartialEq, Clone)]
+        struct Counts {
+            #[bits(16)]
+            ancount: u16,
+            #[bits(16)]
+            qdcount: u16,
+        }
+
+        #[derive(BeBytes, Debug, PartialEq, Clone)]
+        struct NestedHeader {
+            #[bits(16)]
+            flags: u16,
+            counts: Counts,
+        }
+
+        #[derive(BeBytes, Debug, PartialEq, Clone)]
+        struct ComplexPacket {
+            header: NestedHeader,
+            #[FromField(header.counts.ancount)]
+            answers: Vec<u8>,
+            #[FromField(header.counts.qdcount)]
+            questions: Vec<u8>,
+        }
+
+        let packet = ComplexPacket {
+            header: NestedHeader {
+                flags: 0x8180,
+                counts: Counts {
+                    ancount: 3,
+                    qdcount: 2,
+                },
+            },
+            answers: vec![1, 2, 3],
+            questions: vec![4, 5],
+        };
+
+        let bytes = packet.to_be_bytes();
+        let (deserialized, _) = ComplexPacket::try_from_be_bytes(&bytes).unwrap();
+
+        assert_eq!(packet, deserialized);
+        assert_eq!(deserialized.answers.len(), 3);
+        assert_eq!(deserialized.questions.len(), 2);
+    }
+}
+

--- a/bebytes/tests/nested_field_test.rs
+++ b/bebytes/tests/nested_field_test.rs
@@ -2,7 +2,6 @@ use bebytes::BeBytes;
 
 #[derive(BeBytes, Debug, PartialEq, Clone)]
 struct DnsHeader {
-    #[bits(16)]
     transaction_id: u16,
     #[bits(1)]
     qr: u8,
@@ -20,13 +19,9 @@ struct DnsHeader {
     z: u8,
     #[bits(4)]
     rcode: u8,
-    #[bits(16)]
     qdcount: u16,
-    #[bits(16)]
     ancount: u16,
-    #[bits(16)]
     nscount: u16,
-    #[bits(16)]
     arcount: u16,
 }
 
@@ -103,15 +98,12 @@ mod tests {
     fn test_deeply_nested_field_access() {
         #[derive(BeBytes, Debug, PartialEq, Clone)]
         struct Counts {
-            #[bits(16)]
             ancount: u16,
-            #[bits(16)]
             qdcount: u16,
         }
 
         #[derive(BeBytes, Debug, PartialEq, Clone)]
         struct NestedHeader {
-            #[bits(16)]
             flags: u16,
             counts: Counts,
         }
@@ -145,4 +137,3 @@ mod tests {
         assert_eq!(deserialized.questions.len(), 2);
     }
 }
-

--- a/bebytes_derive/src/attrs.rs
+++ b/bebytes_derive/src/attrs.rs
@@ -8,7 +8,7 @@ pub fn parse_attributes(
     attributes: &[syn::Attribute],
     bits_attribute_present: &mut bool,
     errors: &mut Vec<proc_macro2::TokenStream>,
-) -> (Option<usize>, Option<proc_macro2::Ident>) {
+) -> (Option<usize>, Option<Vec<proc_macro2::Ident>>) {
     match crate::functional::functional_attrs::parse_attributes_functional(attributes) {
         Ok(attr_data) => {
             *bits_attribute_present = attr_data.is_bits_attribute;


### PR DESCRIPTION
## Summary
- Add support for nested field access using dot notation in `#[FromField]` attribute
- Enable referencing fields in nested structs like `#[FromField(header.count)]`

## Changes
- Update `AttributeData` to store field paths as `Vec<Ident>`
- Parse dot-separated field paths in `parse_from_field_attribute_functional`
- Generate correct field access expressions for parsing and serialization
- Add tests for nested field access
- Update documentation and examples

## Test Plan
- [x] All existing tests pass
- [x] New nested field access tests pass
- [x] Macro expansion works correctly
- [x] Visual validation in macro_test.rs