### PR TITLE
chore: update bebytes to 1.5.0 and use bebytes_derive 1.5.0

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -18,7 +18,7 @@ name = "performance_benchmark"
 path = "./bin/performance_benchmark.rs"
 
 [dependencies]
-bebytes_derive = "1.4.0"
+bebytes_derive = "1.5.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }


### PR DESCRIPTION
## Summary
- Update bebytes version to 1.5.0
- Update dependency to bebytes_derive 1.5.0 (now includes nested field access)

## Context
This release includes the nested field access feature for `#[FromField]` attribute that supports dot notation like `#[FromField(header.count)]`.