### PR TITLE
feat: add flag decomposition methods for flag enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ For flag enums, the following additional methods are generated:
 - **Bitwise Operators**: `BitOr`, `BitAnd`, `BitXor`, `Not` implementations
 - **`contains(self, flag: Self) -> bool`**: Check if a specific flag is set
 - **`from_bits(bits: u8) -> Option<u8>`**: Validate and create a flag combination from raw bits
+- **`decompose(bits: u8) -> Vec<Self>`**: Decompose a u8 value into individual flag variants
+- **`iter_flags(bits: u8) -> impl Iterator<Item = Self>`**: Iterate over individual flag variants set in a u8 value
 
 #### Example: Network Protocol Flags
 
@@ -309,9 +311,25 @@ let packet = NetworkPacket {
 let bytes = packet.to_be_bytes();
 let (decoded, _) = NetworkPacket::try_from_be_bytes(&bytes).unwrap();
 
-// Check individual flags
+// Check individual flags (traditional method)
 let has_encryption = (decoded.flags & ProtocolFlags::Encrypted as u8) != 0;
 let has_compression = (decoded.flags & ProtocolFlags::Compressed as u8) != 0;
+
+// Decompose flags into individual variants (new method)
+let active_flags = ProtocolFlags::decompose(decoded.flags);
+println!("Active flags: {:?}", active_flags);
+// Output: [Encrypted, Authenticated, KeepAlive]
+
+// Iterate over active flags efficiently
+for flag in ProtocolFlags::iter_flags(decoded.flags) {
+    match flag {
+        ProtocolFlags::Encrypted => println!("Packet is encrypted"),
+        ProtocolFlags::Authenticated => println!("Packet is authenticated"),
+        ProtocolFlags::KeepAlive => println!("Keep-alive flag set"),
+        ProtocolFlags::Compressed => println!("Packet is compressed"),
+        ProtocolFlags::Priority => println!("High priority packet"),
+    }
+}
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use BeBytes Derive, add it as a dependency in your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-bebytes = "2.0.0"
+bebytes = "2.1.0"
 ```
 
 Then, import the BeBytes trait from the bebytes_derive crate and derive it for your struct:

--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -12,10 +12,12 @@ keywords = ["serialization", "deserialization", "network", "bytes", "no-std"]
 [[bin]]
 name = "macro_test"
 path = "./bin/macro_test.rs"
+required-features = ["std"]
 
 [[bin]]
 name = "performance_benchmark"
 path = "./bin/performance_benchmark.rs"
+required-features = ["std"]
 
 [dependencies]
 bebytes_derive = { version = "2.1.0", path = "../bebytes_derive" }

--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -18,7 +18,7 @@ name = "performance_benchmark"
 path = "./bin/performance_benchmark.rs"
 
 [dependencies]
-bebytes_derive = { version = "2.0.0", path = "../bebytes_derive" }
+bebytes_derive = { version = "2.1.0", path = "../bebytes_derive" }
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes/tests/compile_fail.rs
+++ b/bebytes/tests/compile_fail.rs
@@ -10,6 +10,7 @@ fn ui_tests() {
     t.compile_fail("tests/compile_time/unsupported_char.rs");
     t.compile_fail("tests/compile_time/unsupported_isize.rs");
     t.compile_fail("tests/compile_time/enum_discriminant_too_large.rs");
+    #[cfg(feature = "std")]
     t.compile_fail("tests/compile_time/invalid_flag_enum.rs");
 
     // Success tests
@@ -20,5 +21,7 @@ fn ui_tests() {
     t.pass("tests/compile_time/nested_struct.rs");
     t.pass("tests/compile_time/arrayed.rs");
     t.pass("tests/compile_time/safe_nested_vector.rs");
+    
+    #[cfg(feature = "std")]
     t.pass("tests/compile_time/zero_value_flag_enum.rs");
 }

--- a/bebytes/tests/compile_fail.rs
+++ b/bebytes/tests/compile_fail.rs
@@ -21,7 +21,7 @@ fn ui_tests() {
     t.pass("tests/compile_time/nested_struct.rs");
     t.pass("tests/compile_time/arrayed.rs");
     t.pass("tests/compile_time/safe_nested_vector.rs");
-    
+
     #[cfg(feature = "std")]
     t.pass("tests/compile_time/zero_value_flag_enum.rs");
 }

--- a/bebytes/tests/enums.rs
+++ b/bebytes/tests/enums.rs
@@ -275,6 +275,84 @@ mod flag_enums {
         let from_zero = StatusFlags::from_bits(0).unwrap();
         assert_eq!(from_zero, 0u8); // from_bits returns u8
     }
+
+    #[test]
+    fn test_flag_decomposition() {
+        // Test empty flags
+        let empty_flags = StatusFlags::decompose(0);
+        assert!(empty_flags.is_empty());
+
+        // Test single flag
+        let single_flags = StatusFlags::decompose(StatusFlags::Ready as u8);
+        assert_eq!(single_flags.len(), 1);
+        assert_eq!(single_flags[0], StatusFlags::Ready);
+
+        // Test multiple flags
+        let combined = StatusFlags::Ready as u8 | StatusFlags::Complete as u8;
+        let multi_flags = StatusFlags::decompose(combined);
+        assert_eq!(multi_flags.len(), 2);
+        assert!(multi_flags.contains(&StatusFlags::Ready));
+        assert!(multi_flags.contains(&StatusFlags::Complete));
+        assert!(!multi_flags.contains(&StatusFlags::Busy));
+
+        // Test all flags
+        let all_flags_value = StatusFlags::Ready as u8
+            | StatusFlags::Busy as u8
+            | StatusFlags::Complete as u8
+            | StatusFlags::ErrorStatus as u8;
+        let all_flags = StatusFlags::decompose(all_flags_value);
+        assert_eq!(all_flags.len(), 4);
+        assert!(all_flags.contains(&StatusFlags::Ready));
+        assert!(all_flags.contains(&StatusFlags::Busy));
+        assert!(all_flags.contains(&StatusFlags::Complete));
+        assert!(all_flags.contains(&StatusFlags::ErrorStatus));
+    }
+
+    #[test]
+    fn test_flag_iter() {
+        // Test iter_flags with multiple flags
+        let combined = StatusFlags::Ready as u8 | StatusFlags::Complete as u8;
+        let flag_iter: Vec<_> = StatusFlags::iter_flags(combined).collect();
+        assert_eq!(flag_iter.len(), 2);
+        assert!(flag_iter.contains(&StatusFlags::Ready));
+        assert!(flag_iter.contains(&StatusFlags::Complete));
+
+        // Test iter_flags with empty
+        let empty_iter: Vec<_> = StatusFlags::iter_flags(0).collect();
+        assert!(empty_iter.is_empty());
+
+        // Test iter_flags with single flag
+        let single_iter: Vec<_> = StatusFlags::iter_flags(StatusFlags::Busy as u8).collect();
+        assert_eq!(single_iter.len(), 1);
+        assert_eq!(single_iter[0], StatusFlags::Busy);
+    }
+
+    #[test]
+    fn test_flag_decomposition_round_trip() {
+        // Create combined flags
+        let original = StatusFlags::Ready as u8 | StatusFlags::ErrorStatus as u8;
+
+        // Decompose
+        let decomposed = StatusFlags::decompose(original);
+
+        // Reconstruct
+        let reconstructed = decomposed.iter().fold(0u8, |acc, flag| acc | (*flag as u8));
+
+        assert_eq!(original, reconstructed);
+    }
+
+    #[test]
+    fn test_flag_decomposition_invalid_bits() {
+        // Test with invalid bit combination (16 is not a valid flag)
+        let invalid_flags = StatusFlags::decompose(16);
+        assert!(invalid_flags.is_empty()); // Should return empty since 16 doesn't match any flag
+
+        // Test with partially valid combination
+        let partial = StatusFlags::Ready as u8 | 16; // Ready + invalid bit
+        let partial_flags = StatusFlags::decompose(partial);
+        assert_eq!(partial_flags.len(), 1);
+        assert_eq!(partial_flags[0], StatusFlags::Ready);
+    }
 }
 
 mod enum_bit_packing {

--- a/bebytes/tests/enums.rs
+++ b/bebytes/tests/enums.rs
@@ -166,6 +166,7 @@ mod auto_sized_enums {
     }
 }
 
+#[cfg(feature = "std")]
 mod flag_enums {
     use super::*;
 

--- a/bebytes/tests/integration.rs
+++ b/bebytes/tests/integration.rs
@@ -8,6 +8,7 @@
 
 use bebytes::BeBytes;
 
+#[cfg(feature = "std")]
 mod packet_protocols {
     use super::*;
 
@@ -346,6 +347,7 @@ mod performance_scenarios {
     }
 }
 
+#[cfg(feature = "std")]
 mod edge_case_integration {
     use super::*;
 

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -423,6 +423,49 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                                     None
                                 }
                             }
+
+                            /// Decompose a u8 value into individual flag variants
+                            #[cfg(feature = "std")]
+                            pub fn decompose(bits: u8) -> std::vec::Vec<Self> {
+                                let mut flags = std::vec::Vec::new();
+                                #(
+                                    if bits & #variant_values == #variant_values && #variant_values != 0 {
+                                        if let Ok(flag) = Self::try_from(#variant_values) {
+                                            flags.push(flag);
+                                        }
+                                    }
+                                )*
+                                flags
+                            }
+
+                            /// Decompose a u8 value into individual flag variants (no_std)
+                            #[cfg(not(feature = "std"))]
+                            pub fn decompose(bits: u8) -> alloc::vec::Vec<Self> {
+                                let mut flags = alloc::vec::Vec::new();
+                                #(
+                                    if bits & #variant_values == #variant_values && #variant_values != 0 {
+                                        if let Ok(flag) = Self::try_from(#variant_values) {
+                                            flags.push(flag);
+                                        }
+                                    }
+                                )*
+                                flags
+                            }
+
+                            /// Iterate over individual flag variants set in a u8 value
+                            pub fn iter_flags(bits: u8) -> impl Iterator<Item = Self> {
+                                [
+                                    #(
+                                        if bits & #variant_values == #variant_values && #variant_values != 0 {
+                                            Self::try_from(#variant_values).ok()
+                                        } else {
+                                            None
+                                        },
+                                    )*
+                                ]
+                                .into_iter()
+                                .flatten()
+                            }
                         }
                     }
                 } else {

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -426,8 +426,8 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
 
                             /// Decompose a u8 value into individual flag variants
                             #[cfg(feature = "std")]
-                            pub fn decompose(bits: u8) -> std::vec::Vec<Self> {
-                                let mut flags = std::vec::Vec::new();
+                            pub fn decompose(bits: u8) -> Vec<Self> {
+                                let mut flags = Vec::new();
                                 #(
                                     if bits & #variant_values == #variant_values && #variant_values != 0 {
                                         if let Ok(flag) = Self::try_from(#variant_values) {
@@ -440,8 +440,8 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
 
                             /// Decompose a u8 value into individual flag variants (no_std)
                             #[cfg(not(feature = "std"))]
-                            pub fn decompose(bits: u8) -> alloc::vec::Vec<Self> {
-                                let mut flags = alloc::vec::Vec::new();
+                            pub fn decompose(bits: u8) -> ::alloc::vec::Vec<Self> {
+                                let mut flags = ::alloc::vec::Vec::new();
                                 #(
                                     if bits & #variant_values == #variant_values && #variant_values != 0 {
                                         if let Ok(flag) = Self::try_from(#variant_values) {


### PR DESCRIPTION
## Summary

This PR adds convenient flag decomposition methods for flag enums, allowing users to easily extract individual flag variants from a combined u8 value.

### New Features

- **`decompose(bits: u8) -> Vec<Self>`**: Decompose a u8 value into individual flag variants
- **`iter_flags(bits: u8) -> impl Iterator<Item = Self>`**: Memory-efficient iteration over set flags
- Full `std` and `no_std` support
- Comprehensive test coverage
- Updated documentation with practical examples

### Example Usage

```rust
#[derive(BeBytes, Debug, PartialEq, Copy, Clone)]
#[bebytes(flags)]
enum Permissions {
    None = 0,
    Read = 1,
    Write = 2,
    Execute = 4,
}

let combined = 7u8; // Read | Write | Execute
let flags = Permissions::decompose(combined);
// Returns: [Permissions::Read, Permissions::Write, Permissions::Execute]

// Or iterate efficiently
for flag in Permissions::iter_flags(combined) {
    println!("Active flag: {:?}", flag);
}
```

### Breaking Changes

None - this is a backward-compatible feature addition.

### Test Coverage

- Basic decomposition functionality
- Iterator behavior  
- Round-trip conversion
- Invalid bit handling
- Edge cases (empty, single flags)