### PR TITLE
fix: resolve Vec path resolution in no_std environments (v2.1.1)

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -20,7 +20,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "2.1.0", path = "../bebytes_derive" }
+bebytes_derive = { version = "2.1.1", path = "../bebytes_derive" }
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes/src/lib.rs
+++ b/bebytes/src/lib.rs
@@ -8,6 +8,12 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 pub use alloc::borrow::ToOwned;
 
+// Re-export Vec for use in generated code
+#[cfg(feature = "std")]
+pub use std::vec::Vec;
+#[cfg(not(feature = "std"))]
+pub use alloc::vec::Vec;
+
 pub use bebytes_derive::BeBytes;
 
 /// Error type for `BeBytes` operations

--- a/bebytes/src/lib.rs
+++ b/bebytes/src/lib.rs
@@ -9,10 +9,10 @@ extern crate alloc;
 pub use alloc::borrow::ToOwned;
 
 // Re-export Vec for use in generated code
-#[cfg(feature = "std")]
-pub use std::vec::Vec;
 #[cfg(not(feature = "std"))]
 pub use alloc::vec::Vec;
+#[cfg(feature = "std")]
+pub use std::vec::Vec;
 
 pub use bebytes_derive::BeBytes;
 

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -426,8 +426,8 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
 
                             /// Decompose a u8 value into individual flag variants
                             #[cfg(feature = "std")]
-                            pub fn decompose(bits: u8) -> Vec<Self> {
-                                let mut flags = Vec::new();
+                            pub fn decompose(bits: u8) -> ::bebytes::Vec<Self> {
+                                let mut flags = ::bebytes::Vec::new();
                                 #(
                                     if bits & #variant_values == #variant_values && #variant_values != 0 {
                                         if let Ok(flag) = Self::try_from(#variant_values) {
@@ -440,8 +440,8 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
 
                             /// Decompose a u8 value into individual flag variants (no_std)
                             #[cfg(not(feature = "std"))]
-                            pub fn decompose(bits: u8) -> ::alloc::vec::Vec<Self> {
-                                let mut flags = ::alloc::vec::Vec::new();
+                            pub fn decompose(bits: u8) -> ::bebytes::Vec<Self> {
+                                let mut flags = ::bebytes::Vec::new();
                                 #(
                                     if bits & #variant_values == #variant_values && #variant_values != 0 {
                                         if let Ok(flag) = Self::try_from(#variant_values) {


### PR DESCRIPTION
## Summary
- Fixes critical bug where flag enum `decompose()` method fails to compile in user code without `extern crate alloc;`
- Adds Vec re-export to bebytes crate for both std and no_std environments  
- Updates generated code to use `::bebytes::Vec` instead of `::alloc::vec::Vec`

## Problem
In v2.1.0, the generated code for flag enums uses `::alloc::vec::Vec<Self>` which requires users to have `extern crate alloc;` in their code. This breaks existing code that worked with v2.0.0.

## Solution
Re-export Vec from the bebytes crate and use that path in generated code, ensuring Vec is always available through the bebytes namespace.

## Testing
- Verified fix works with test project that has no `extern crate alloc;`
- All existing tests pass including no_std tests
- Tested both std and no_std compilation modes

This is a patch release (2.1.1) that fixes a regression introduced in 2.1.0.