### PR TITLE
fix: remove cfg checks from generated code (v2.1.2)

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fabracht/bebytes_macro"
@@ -20,7 +20,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "2.1.1", path = "../bebytes_derive" }
+bebytes_derive = { version = "2.1.2", path = "../bebytes_derive" }
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -425,21 +425,6 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                             }
 
                             /// Decompose a u8 value into individual flag variants
-                            #[cfg(feature = "std")]
-                            pub fn decompose(bits: u8) -> ::bebytes::Vec<Self> {
-                                let mut flags = ::bebytes::Vec::new();
-                                #(
-                                    if bits & #variant_values == #variant_values && #variant_values != 0 {
-                                        if let Ok(flag) = Self::try_from(#variant_values) {
-                                            flags.push(flag);
-                                        }
-                                    }
-                                )*
-                                flags
-                            }
-
-                            /// Decompose a u8 value into individual flag variants (no_std)
-                            #[cfg(not(feature = "std"))]
                             pub fn decompose(bits: u8) -> ::bebytes::Vec<Self> {
                                 let mut flags = ::bebytes::Vec::new();
                                 #(


### PR DESCRIPTION
## Summary
- Removes `#[cfg(feature = "std")]` attributes from generated code that were causing warnings in user crates
- The cfg checks were being evaluated in the user's crate context, not bebytes' context
- This caused warnings for crates that don't define an std feature

## Problem
When the BeBytes derive macro generates code like:
```rust
#[cfg(feature = "std")]
pub fn decompose(bits: u8) -> ::bebytes::Vec<Self> { ... }
```

The `cfg(feature = "std")` check looks for the std feature in the user's crate (e.g., mqtt-v5), not in bebytes. This causes Rust's check-cfg system to warn because the user's crate doesn't define an std feature.

## Solution
Since v2.1.1, we use `::bebytes::Vec` which already handles the std/no_std distinction internally. Therefore, we don't need conditional compilation in the generated code - we can generate a single version that works in both contexts.

## Testing
- Created test project without std feature defined
- Verified no cfg warnings are generated
- All existing tests pass in both std and no_std modes

This is a patch release (2.1.2) that improves the developer experience by eliminating spurious warnings.