### PR TITLE
chore: update bebytes to 2.7.0 and use bebytes_derive 2.7.0

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT"
@@ -21,7 +21,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "2.6.0" }
+bebytes_derive = { version = "2.7.0" }
 bytes = { version = "1.5", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Update bebytes_derive dependency from 2.6.0 to 2.7.0 (now published to crates.io)
- Bump bebytes version from 2.6.0 to 2.7.0

## Changes
- bebytes_derive 2.7.0 includes all the performance optimization features from PR #55
- This prepares bebytes for publishing with the latest optimizations

## Next Steps
After this PR is merged, we'll publish bebytes 2.7.0 to crates.io.