### PR TITLE
chore: update bebytes to 2.9.0 with marker attributes

### DIFF
--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT"
@@ -21,7 +21,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "2.8.0" }
+bebytes_derive = { version = "2.9.0" }
 
 [dev-dependencies]
 trybuild = { version = "1.0.102", features = ["diff"] }


### PR DESCRIPTION
## Summary
Update bebytes to version 2.9.0 to match the newly published bebytes_derive 2.9.0

## Changes
- Update bebytes version from 2.8.0 to 2.9.0
- Update bebytes_derive dependency from 2.8.0 to 2.9.0

## Testing
All tests pass with the updated dependency

## Features Added in 2.9.0
- Marker attributes: #[UntilMarker(byte)] and #[AfterMarker(byte)]
- Vec<Vec<u8>> support with marker delimiting
- Comprehensive test coverage for new features