### PR TITLE
feat: add array support and fix Option field handling

### DIFF
--- a/BEBYTES_REFERENCE.md
+++ b/BEBYTES_REFERENCE.md
@@ -8,7 +8,7 @@ BeBytes is a high-performance Rust derive macro for binary serialization/deseria
 
 ```toml
 [dependencies]
-bebytes = "2.8.0"
+bebytes = "3.0.0"
 ```
 
 ## Basic Usage
@@ -185,15 +185,25 @@ let perms = Permissions::Read | Permissions::Write;  // = 3
 ```
 
 ### Options
-Supported for primitive types only:
+Supported for primitives and byte arrays:
 
 ```rust
 #[derive(BeBytes)]
 struct OptionalFields {
     required: u32,
-    optional: Option<u16>,  // None serializes as zeros
+    opt_int: Option<u16>,
+    opt_float: Option<f32>,
+    opt_bool: Option<bool>,
+    opt_char: Option<char>,
+    opt_array: Option<[u8; 4]>,
 }
 ```
+
+Options use a tagged wire format:
+- `None` → `[0x00, zeros...]` (tag + padding)
+- `Some(val)` → `[0x01, value...]` (tag + value bytes)
+
+This disambiguates `Some(0)` from `None`. Field size = inner size + 1 byte for tag.
 
 ## Important Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2025-12-21
+
+### Breaking Changes
+
+- **Option wire format changed**: Options now use a tagged format for unambiguous serialization
+  - `None` → `[0x00, zeros...]` (1 tag byte + N zero-padding bytes)
+  - `Some(value)` → `[0x01, value...]` (1 tag byte + value bytes)
+  - This fixes the ambiguity where `Some(0)` was indistinguishable from `None`
+  - `field_size()` now returns inner type size + 1 byte for the tag
+  - **Wire format is incompatible with previous versions**
+
+### Added
+
+- **Option<[u8; N]> array support**: Byte arrays can now be wrapped in Option
+- **Option support for f32, f64, bool, char**: All primitive types now work with Option
+- **InvalidChar error variant**: Proper error type for invalid Unicode code points in char fields
+- Comprehensive test suite for all Option types (32 tests)
+- Little-endian round-trip tests for Options
+
+### Fixed
+
+- `Some(0)` vs `None` disambiguation issue
+- Invalid char validation now uses `InvalidChar` error instead of `InvalidDiscriminant`
+
 ## [2.11.0] - 2025-12-09
 
 ### Added

--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "2.12.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT"
@@ -21,7 +21,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "2.12.0" }
+bebytes_derive = { version = "3.0.0" }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/bebytes/src/lib.rs
+++ b/bebytes/src/lib.rs
@@ -138,6 +138,9 @@ pub enum BeBytesError {
         marker: u8,
         field: &'static str,
     },
+    InvalidChar {
+        value: u32,
+    },
 }
 
 impl core::fmt::Display for BeBytesError {
@@ -161,6 +164,9 @@ impl core::fmt::Display for BeBytesError {
             }
             Self::MarkerNotFound { marker, field } => {
                 write!(f, "Marker byte 0x{marker:02X} not found in field '{field}'")
+            }
+            Self::InvalidChar { value } => {
+                write!(f, "Invalid Unicode code point: 0x{value:08X}")
             }
         }
     }

--- a/bebytes/tests/comparison_mutations.rs
+++ b/bebytes/tests/comparison_mutations.rs
@@ -49,11 +49,11 @@ fn test_option_type_identification() {
     };
 
     let bytes_some = test_some.to_be_bytes();
-    // Option<u32> in BeBytes just includes the value if Some
-    assert_eq!(bytes_some.len(), 6); // 1 + 4 + 1
+    assert_eq!(bytes_some.len(), 7);
     assert_eq!(bytes_some[0], 0xAA);
-    assert_eq!(&bytes_some[1..5], &[0x12, 0x34, 0x56, 0x78]);
-    assert_eq!(bytes_some[5], 0xBB);
+    assert_eq!(bytes_some[1], 0x01);
+    assert_eq!(&bytes_some[2..6], &[0x12, 0x34, 0x56, 0x78]);
+    assert_eq!(bytes_some[6], 0xBB);
 }
 
 #[test]

--- a/bebytes/tests/logical_mutations.rs
+++ b/bebytes/tests/logical_mutations.rs
@@ -176,10 +176,8 @@ fn test_conditional_field_types() {
     };
 
     let bytes_some = test_some.to_be_bytes();
-    // primitive(4) + array(5) + option with Some(2) + bits(2) = 13
-    assert_eq!(bytes_some.len(), 13);
+    assert_eq!(bytes_some.len(), 14);
 
-    // Test with None
     let test_none = MixedFieldTypes {
         primitive: 0x12345678,
         array: [1, 2, 3, 4, 5],
@@ -188,9 +186,7 @@ fn test_conditional_field_types() {
     };
 
     let bytes_none = test_none.to_be_bytes();
-    // Option<u32> seems to always serialize the value, even for None
-    // primitive(4) + array(5) + option(2) + bits(2) = 13
-    assert_eq!(bytes_none.len(), 13);
+    assert_eq!(bytes_none.len(), 14);
 }
 
 #[test]

--- a/bebytes/tests/option_types.rs
+++ b/bebytes/tests/option_types.rs
@@ -451,3 +451,24 @@ fn test_option_array_invalid_tag() {
     let result = OptionArray4::try_from_be_bytes(&invalid_bytes);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_option_little_endian_round_trip() {
+    let s = OptionU32 {
+        value: Some(0x12345678),
+    };
+    let bytes = s.to_le_bytes();
+    assert_eq!(bytes.len(), 5);
+    assert_eq!(bytes[0], 0x01);
+    assert_eq!(&bytes[1..5], &[0x78, 0x56, 0x34, 0x12]);
+
+    let (parsed, _) = OptionU32::try_from_le_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, Some(0x12345678));
+
+    let none = OptionU32 { value: None };
+    let none_bytes = none.to_le_bytes();
+    assert_eq!(none_bytes[0], 0x00);
+
+    let (parsed_none, _) = OptionU32::try_from_le_bytes(&none_bytes).unwrap();
+    assert_eq!(parsed_none.value, None);
+}

--- a/bebytes/tests/option_types.rs
+++ b/bebytes/tests/option_types.rs
@@ -1,0 +1,364 @@
+use bebytes::BeBytes;
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionU8 {
+    value: Option<u8>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionU16 {
+    value: Option<u16>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionU32 {
+    value: Option<u32>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionU64 {
+    value: Option<u64>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionU128 {
+    value: Option<u128>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionI8 {
+    value: Option<i8>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionI16 {
+    value: Option<i16>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionI32 {
+    value: Option<i32>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionI64 {
+    value: Option<i64>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionI128 {
+    value: Option<i128>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionF32 {
+    value: Option<f32>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionF64 {
+    value: Option<f64>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionBool {
+    value: Option<bool>,
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct OptionChar {
+    value: Option<char>,
+}
+
+#[test]
+fn test_option_u8_some_zero_disambiguated() {
+    let some_zero = OptionU8 { value: Some(0) };
+    let none = OptionU8 { value: None };
+
+    let some_zero_bytes = some_zero.to_be_bytes();
+    let none_bytes = none.to_be_bytes();
+
+    assert_ne!(some_zero_bytes, none_bytes);
+    assert_eq!(some_zero_bytes, [0x01, 0x00]);
+    assert_eq!(none_bytes, [0x00, 0x00]);
+
+    let (parsed_some, _) = OptionU8::try_from_be_bytes(&some_zero_bytes).unwrap();
+    let (parsed_none, _) = OptionU8::try_from_be_bytes(&none_bytes).unwrap();
+
+    assert_eq!(parsed_some.value, Some(0));
+    assert_eq!(parsed_none.value, None);
+}
+
+#[test]
+fn test_option_u8_some_value() {
+    let s = OptionU8 { value: Some(42) };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes, [0x01, 42]);
+
+    let (parsed, consumed) = OptionU8::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, Some(42));
+    assert_eq!(consumed, 2);
+}
+
+#[test]
+fn test_option_u16_round_trip() {
+    for val in [0u16, 1, 255, 256, u16::MAX] {
+        let s = OptionU16 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        assert_eq!(bytes[0], 0x01);
+
+        let (parsed, consumed) = OptionU16::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+        assert_eq!(consumed, 3);
+    }
+}
+
+#[test]
+fn test_option_u32_round_trip() {
+    for val in [0u32, 1, u32::MAX] {
+        let s = OptionU32 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionU32::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_u64_round_trip() {
+    for val in [0u64, 1, u64::MAX] {
+        let s = OptionU64 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionU64::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_u128_round_trip() {
+    for val in [0u128, 1, u128::MAX] {
+        let s = OptionU128 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionU128::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_i8_round_trip() {
+    for val in [i8::MIN, -1, 0, 1, i8::MAX] {
+        let s = OptionI8 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionI8::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_i16_round_trip() {
+    for val in [i16::MIN, -1, 0, 1, i16::MAX] {
+        let s = OptionI16 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionI16::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_i32_round_trip() {
+    for val in [i32::MIN, -1, 0, 1, i32::MAX] {
+        let s = OptionI32 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionI32::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_i64_round_trip() {
+    for val in [i64::MIN, -1, 0, 1, i64::MAX] {
+        let s = OptionI64 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionI64::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_i128_round_trip() {
+    for val in [i128::MIN, -1, 0, 1, i128::MAX] {
+        let s = OptionI128 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionI128::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_f32_round_trip() {
+    for val in [0.0f32, 1.0, -1.0, 3.14159, f32::MAX, f32::MIN] {
+        let s = OptionF32 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        assert_eq!(bytes[0], 0x01);
+        let (parsed, _) = OptionF32::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_f32_none() {
+    let s = OptionF32 { value: None };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes[0], 0x00);
+    let (parsed, _) = OptionF32::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, None);
+}
+
+#[test]
+fn test_option_f64_round_trip() {
+    for val in [0.0f64, 1.0, -1.0, f64::MAX, f64::MIN] {
+        let s = OptionF64 { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        let (parsed, _) = OptionF64::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_f64_none() {
+    let s = OptionF64 { value: None };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes[0], 0x00);
+    let (parsed, _) = OptionF64::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, None);
+}
+
+#[test]
+fn test_option_bool_some_true() {
+    let s = OptionBool { value: Some(true) };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes, [0x01, 0x01]);
+    let (parsed, _) = OptionBool::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, Some(true));
+}
+
+#[test]
+fn test_option_bool_some_false() {
+    let s = OptionBool { value: Some(false) };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes, [0x01, 0x00]);
+    let (parsed, _) = OptionBool::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, Some(false));
+}
+
+#[test]
+fn test_option_bool_none() {
+    let s = OptionBool { value: None };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes, [0x00, 0x00]);
+    let (parsed, _) = OptionBool::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, None);
+}
+
+#[test]
+fn test_option_char_round_trip() {
+    for val in ['A', 'z', '\u{1F600}', '\0'] {
+        let s = OptionChar { value: Some(val) };
+        let bytes = s.to_be_bytes();
+        assert_eq!(bytes[0], 0x01);
+        let (parsed, _) = OptionChar::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(parsed.value, Some(val));
+    }
+}
+
+#[test]
+fn test_option_char_none() {
+    let s = OptionChar { value: None };
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes[0], 0x00);
+    let (parsed, _) = OptionChar::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed.value, None);
+}
+
+#[test]
+fn test_option_field_sizes() {
+    assert_eq!(OptionU8::field_size(), 2);
+    assert_eq!(OptionU16::field_size(), 3);
+    assert_eq!(OptionU32::field_size(), 5);
+    assert_eq!(OptionU64::field_size(), 9);
+    assert_eq!(OptionU128::field_size(), 17);
+    assert_eq!(OptionI8::field_size(), 2);
+    assert_eq!(OptionI16::field_size(), 3);
+    assert_eq!(OptionI32::field_size(), 5);
+    assert_eq!(OptionI64::field_size(), 9);
+    assert_eq!(OptionI128::field_size(), 17);
+    assert_eq!(OptionF32::field_size(), 5);
+    assert_eq!(OptionF64::field_size(), 9);
+    assert_eq!(OptionBool::field_size(), 2);
+    assert_eq!(OptionChar::field_size(), 5);
+}
+
+#[test]
+fn test_invalid_option_tag() {
+    let invalid_bytes = [0x02, 0x00];
+    let result = OptionU8::try_from_be_bytes(&invalid_bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_option_char_invalid_unicode() {
+    let invalid_bytes = [0x01, 0x00, 0xD8, 0x00, 0x00];
+    let result = OptionChar::try_from_be_bytes(&invalid_bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_option_in_mixed_struct() {
+    #[derive(BeBytes, Debug, PartialEq)]
+    struct MixedStruct {
+        prefix: u8,
+        opt_value: Option<u16>,
+        suffix: u32,
+    }
+
+    let s = MixedStruct {
+        prefix: 0xAA,
+        opt_value: Some(0x1234),
+        suffix: 0xDEADBEEF,
+    };
+
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes.len(), 1 + 3 + 4);
+    assert_eq!(bytes[0], 0xAA);
+    assert_eq!(bytes[1], 0x01);
+    assert_eq!(bytes[2..4], [0x12, 0x34]);
+    assert_eq!(bytes[4..8], [0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let (parsed, _) = MixedStruct::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed, s);
+}
+
+#[test]
+fn test_option_none_in_mixed_struct() {
+    #[derive(BeBytes, Debug, PartialEq)]
+    struct MixedStruct {
+        prefix: u8,
+        opt_value: Option<u16>,
+        suffix: u32,
+    }
+
+    let s = MixedStruct {
+        prefix: 0xAA,
+        opt_value: None,
+        suffix: 0xDEADBEEF,
+    };
+
+    let bytes = s.to_be_bytes();
+    assert_eq!(bytes.len(), 1 + 3 + 4);
+    assert_eq!(bytes[0], 0xAA);
+    assert_eq!(bytes[1], 0x00);
+    assert_eq!(bytes[2..4], [0x00, 0x00]);
+    assert_eq!(bytes[4..8], [0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let (parsed, _) = MixedStruct::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(parsed, s);
+}

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "2.12.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 publish = true

--- a/bebytes_derive/src/functional.rs
+++ b/bebytes_derive/src/functional.rs
@@ -297,9 +297,8 @@ pub mod pure_helpers {
                     bytes[byte_index + 2], bytes[byte_index + 3]
                 ]);
                 let #field_name = char::from_u32(char_value)
-                    .ok_or_else(|| ::bebytes::BeBytesError::InvalidDiscriminant {
-                        value: (char_value & 0xFF) as u8,
-                        type_name: "char",
+                    .ok_or_else(|| ::bebytes::BeBytesError::InvalidChar {
+                        value: char_value,
                     })?;
             },
             crate::consts::Endianness::Little => quote! {
@@ -308,9 +307,8 @@ pub mod pure_helpers {
                     bytes[byte_index + 2], bytes[byte_index + 3]
                 ]);
                 let #field_name = char::from_u32(char_value)
-                    .ok_or_else(|| ::bebytes::BeBytesError::InvalidDiscriminant {
-                        value: (char_value & 0xFF) as u8,
-                        type_name: "char",
+                    .ok_or_else(|| ::bebytes::BeBytesError::InvalidChar {
+                        value: char_value,
                     })?;
             },
         }

--- a/bebytes_derive/src/functional.rs
+++ b/bebytes_derive/src/functional.rs
@@ -535,31 +535,96 @@ pub mod pure_helpers {
         }
     }
 
+    fn option_direct_write_special(
+        field_name: &Ident,
+        inner_tp: &syn::TypePath,
+        endianness: crate::consts::Endianness,
+    ) -> Option<TokenStream> {
+        if inner_tp.path.is_ident("bool") {
+            return Some(quote! {
+                match #field_name {
+                    None => { buf.put_u8(0x00); buf.put_u8(0x00); }
+                    Some(v) => { buf.put_u8(0x01); buf.put_u8(if v { 1 } else { 0 }); }
+                }
+            });
+        }
+        if inner_tp.path.is_ident("char") {
+            let conv = match endianness {
+                crate::consts::Endianness::Big => quote! { (v as u32).to_be_bytes() },
+                crate::consts::Endianness::Little => quote! { (v as u32).to_le_bytes() },
+            };
+            return Some(quote! {
+                match #field_name {
+                    None => { buf.put_u8(0x00); buf.put_slice(&[0u8; 4]); }
+                    Some(v) => { buf.put_u8(0x01); buf.put_slice(&#conv); }
+                }
+            });
+        }
+        if inner_tp.path.is_ident("f32") {
+            let conv = match endianness {
+                crate::consts::Endianness::Big => quote! { v.to_be_bytes() },
+                crate::consts::Endianness::Little => quote! { v.to_le_bytes() },
+            };
+            return Some(quote! {
+                match #field_name {
+                    None => { buf.put_u8(0x00); buf.put_slice(&[0u8; 4]); }
+                    Some(v) => { buf.put_u8(0x01); buf.put_slice(&#conv); }
+                }
+            });
+        }
+        if inner_tp.path.is_ident("f64") {
+            let conv = match endianness {
+                crate::consts::Endianness::Big => quote! { v.to_be_bytes() },
+                crate::consts::Endianness::Little => quote! { v.to_le_bytes() },
+            };
+            return Some(quote! {
+                match #field_name {
+                    None => { buf.put_u8(0x00); buf.put_slice(&[0u8; 8]); }
+                    Some(v) => { buf.put_u8(0x01); buf.put_slice(&#conv); }
+                }
+            });
+        }
+        None
+    }
+
+    fn option_direct_write_integer(
+        field_name: &Ident,
+        type_size: usize,
+        endianness: crate::consts::Endianness,
+    ) -> TokenStream {
+        let put_value = match (endianness, type_size) {
+            (_, 1) => quote! { buf.put_u8(v as u8) },
+            (crate::consts::Endianness::Big, 2) => quote! { buf.put_u16(v as u16) },
+            (crate::consts::Endianness::Big, 4) => quote! { buf.put_u32(v as u32) },
+            (crate::consts::Endianness::Big, 8) => quote! { buf.put_u64(v as u64) },
+            (crate::consts::Endianness::Big, 16) => quote! { buf.put_u128(v as u128) },
+            (crate::consts::Endianness::Big, _) => quote! { buf.put_slice(&v.to_be_bytes()) },
+            (crate::consts::Endianness::Little, 2) => quote! { buf.put_u16_le(v as u16) },
+            (crate::consts::Endianness::Little, 4) => quote! { buf.put_u32_le(v as u32) },
+            (crate::consts::Endianness::Little, 8) => quote! { buf.put_u64_le(v as u64) },
+            (crate::consts::Endianness::Little, 16) => quote! { buf.put_u128_le(v as u128) },
+            (crate::consts::Endianness::Little, _) => quote! { buf.put_slice(&v.to_le_bytes()) },
+        };
+        quote! {
+            match #field_name {
+                None => { buf.put_u8(0x00); buf.put_slice(&[0u8; #type_size]); }
+                Some(v) => { buf.put_u8(0x01); #put_value; }
+            }
+        }
+    }
+
     pub fn create_option_primitive_direct_writing(
         field_name: &Ident,
         inner_type: &syn::Type,
+        type_size: usize,
         endianness: crate::consts::Endianness,
-    ) -> Result<TokenStream, syn::Error> {
-        let type_size = crate::utils::get_primitive_type_size(inner_type)?;
-
-        match endianness {
-            crate::consts::Endianness::Big => match type_size {
-                1 => Ok(quote! { buf.put_u8(#field_name.unwrap_or(0) as u8); }),
-                2 => Ok(quote! { buf.put_u16(#field_name.unwrap_or(0) as u16); }),
-                4 => Ok(quote! { buf.put_u32(#field_name.unwrap_or(0) as u32); }),
-                8 => Ok(quote! { buf.put_u64(#field_name.unwrap_or(0) as u64); }),
-                16 => Ok(quote! { buf.put_u128(#field_name.unwrap_or(0) as u128); }),
-                _ => Ok(quote! { buf.put_slice(&#field_name.unwrap_or(0).to_be_bytes()); }),
-            },
-            crate::consts::Endianness::Little => match type_size {
-                1 => Ok(quote! { buf.put_u8(#field_name.unwrap_or(0) as u8); }),
-                2 => Ok(quote! { buf.put_u16_le(#field_name.unwrap_or(0) as u16); }),
-                4 => Ok(quote! { buf.put_u32_le(#field_name.unwrap_or(0) as u32); }),
-                8 => Ok(quote! { buf.put_u64_le(#field_name.unwrap_or(0) as u64); }),
-                16 => Ok(quote! { buf.put_u128_le(#field_name.unwrap_or(0) as u128); }),
-                _ => Ok(quote! { buf.put_slice(&#field_name.unwrap_or(0).to_le_bytes()); }),
-            },
+    ) -> TokenStream {
+        if let syn::Type::Path(inner_tp) = inner_type {
+            if let Some(ts) = option_direct_write_special(field_name, inner_tp, endianness) {
+                return ts;
+            }
         }
+        option_direct_write_integer(field_name, type_size, endianness)
     }
 
     /// Create limit check for bit fields

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -1115,9 +1115,8 @@ fn option_parse_special(
                 bytes[value_start + 2], bytes[value_start + 3]
             ]);
             Some(char::from_u32(char_value)
-                .ok_or_else(|| ::bebytes::BeBytesError::InvalidDiscriminant {
-                    value: (char_value & 0xFF) as u8,
-                    type_name: "char",
+                .ok_or_else(|| ::bebytes::BeBytesError::InvalidChar {
+                    value: char_value,
                 })?)
         }});
     }

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -393,11 +393,10 @@ fn process_field_type(
         }
         FieldType::OptionType => {
             let result = process_option_type_functional(context, processing_ctx)?;
-            // Options of primitives have the size of the primitive
             if let syn::Type::Path(tp) = context.field_type {
                 if let Some(inner_type) = utils::solve_for_inner_type(tp, "Option") {
                     let field_size = utils::get_primitive_type_size(&inner_type)?;
-                    *current_bit_position += field_size * 8;
+                    *current_bit_position += (field_size + 1) * 8;
                 }
             }
             Ok(result)
@@ -1076,7 +1075,146 @@ fn process_vector_functional(
     Err(syn::Error::new_spanned(field_type, "Not a vector type"))
 }
 
-// Functional version of handle_option_type
+fn option_parse_special(
+    inner_tp: &syn::TypePath,
+    endianness: crate::consts::Endianness,
+) -> Option<proc_macro2::TokenStream> {
+    if inner_tp.path.is_ident("bool") {
+        return Some(quote! { Some(bytes[value_start] != 0) });
+    }
+    if inner_tp.path.is_ident("char") {
+        let from_bytes = match endianness {
+            crate::consts::Endianness::Big => quote! { u32::from_be_bytes },
+            crate::consts::Endianness::Little => quote! { u32::from_le_bytes },
+        };
+        return Some(quote! {{
+            let char_value = #from_bytes([
+                bytes[value_start], bytes[value_start + 1],
+                bytes[value_start + 2], bytes[value_start + 3]
+            ]);
+            Some(char::from_u32(char_value)
+                .ok_or_else(|| ::bebytes::BeBytesError::InvalidDiscriminant {
+                    value: (char_value & 0xFF) as u8,
+                    type_name: "char",
+                })?)
+        }});
+    }
+    if inner_tp.path.is_ident("f32") {
+        let from_bytes = match endianness {
+            crate::consts::Endianness::Big => quote! { f32::from_be_bytes },
+            crate::consts::Endianness::Little => quote! { f32::from_le_bytes },
+        };
+        return Some(quote! {
+            Some(#from_bytes([
+                bytes[value_start], bytes[value_start + 1],
+                bytes[value_start + 2], bytes[value_start + 3]
+            ]))
+        });
+    }
+    if inner_tp.path.is_ident("f64") {
+        let from_bytes = match endianness {
+            crate::consts::Endianness::Big => quote! { f64::from_be_bytes },
+            crate::consts::Endianness::Little => quote! { f64::from_le_bytes },
+        };
+        return Some(quote! {
+            Some(#from_bytes([
+                bytes[value_start], bytes[value_start + 1],
+                bytes[value_start + 2], bytes[value_start + 3],
+                bytes[value_start + 4], bytes[value_start + 5],
+                bytes[value_start + 6], bytes[value_start + 7]
+            ]))
+        });
+    }
+    None
+}
+
+fn option_parse_integer(
+    inner_tp: &syn::TypePath,
+    field_size: usize,
+    from_bytes_method: &proc_macro2::TokenStream,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    match field_size {
+        1 => Ok(quote! { Some(bytes[value_start] as #inner_tp) }),
+        2 => Ok(quote! {
+            Some(<#inner_tp>::#from_bytes_method([bytes[value_start], bytes[value_start + 1]]))
+        }),
+        4 => Ok(quote! {
+            Some(<#inner_tp>::#from_bytes_method([
+                bytes[value_start], bytes[value_start + 1],
+                bytes[value_start + 2], bytes[value_start + 3]
+            ]))
+        }),
+        8 => Ok(quote! {
+            Some(<#inner_tp>::#from_bytes_method([
+                bytes[value_start], bytes[value_start + 1], bytes[value_start + 2], bytes[value_start + 3],
+                bytes[value_start + 4], bytes[value_start + 5], bytes[value_start + 6], bytes[value_start + 7]
+            ]))
+        }),
+        16 => Ok(quote! {
+            Some(<#inner_tp>::#from_bytes_method([
+                bytes[value_start], bytes[value_start + 1], bytes[value_start + 2], bytes[value_start + 3],
+                bytes[value_start + 4], bytes[value_start + 5], bytes[value_start + 6], bytes[value_start + 7],
+                bytes[value_start + 8], bytes[value_start + 9], bytes[value_start + 10], bytes[value_start + 11],
+                bytes[value_start + 12], bytes[value_start + 13], bytes[value_start + 14], bytes[value_start + 15]
+            ]))
+        }),
+        _ => Err(syn::Error::new_spanned(
+            inner_tp,
+            "Unsupported primitive type size for Option",
+        )),
+    }
+}
+
+fn create_option_inner_parsing(
+    inner_tp: &syn::TypePath,
+    field_size: usize,
+    endianness: crate::consts::Endianness,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    if let Some(ts) = option_parse_special(inner_tp, endianness) {
+        return Ok(ts);
+    }
+    let from_bytes_method = utils::get_from_bytes_method(endianness);
+    option_parse_integer(inner_tp, field_size, &from_bytes_method)
+}
+
+fn create_option_inner_writing(
+    inner_tp: &syn::TypePath,
+    endianness: crate::consts::Endianness,
+) -> proc_macro2::TokenStream {
+    if inner_tp.path.is_ident("bool") {
+        return quote! {
+            ::bebytes::BufMut::put_u8(bytes, if inner_val { 1 } else { 0 });
+        };
+    }
+
+    if inner_tp.path.is_ident("char") {
+        return match endianness {
+            crate::consts::Endianness::Big => quote! {
+                bytes.extend_from_slice(&(inner_val as u32).to_be_bytes());
+            },
+            crate::consts::Endianness::Little => quote! {
+                bytes.extend_from_slice(&(inner_val as u32).to_le_bytes());
+            },
+        };
+    }
+
+    if inner_tp.path.is_ident("f32") || inner_tp.path.is_ident("f64") {
+        return match endianness {
+            crate::consts::Endianness::Big => quote! {
+                bytes.extend_from_slice(&inner_val.to_be_bytes());
+            },
+            crate::consts::Endianness::Little => quote! {
+                bytes.extend_from_slice(&inner_val.to_le_bytes());
+            },
+        };
+    }
+
+    let to_bytes_method = utils::get_to_bytes_method(endianness);
+    quote! {
+        bytes.extend_from_slice(&inner_val.#to_bytes_method());
+    }
+}
+
 fn process_option_type_functional(
     context: &FieldContext,
     processing_ctx: &crate::functional::ProcessingContext,
@@ -1089,43 +1227,68 @@ fn process_option_type_functional(
             if let syn::Type::Path(inner_tp) = &inner_type {
                 if utils::is_primitive_type(inner_tp) {
                     let field_size = utils::get_primitive_type_size(&inner_type)?;
+                    let total_size = field_size + 1;
 
                     let accessor =
                         crate::functional::pure_helpers::create_field_accessor(field_name, false);
-                    let bit_sum = crate::functional::pure_helpers::create_byte_bit_sum(field_size);
+                    let bit_sum = crate::functional::pure_helpers::create_byte_bit_sum(total_size);
 
-                    let from_bytes_method = utils::get_from_bytes_method(processing_ctx.endianness);
-                    let to_bytes_method = utils::get_to_bytes_method(processing_ctx.endianness);
+                    let value_parsing = create_option_inner_parsing(
+                        inner_tp,
+                        field_size,
+                        processing_ctx.endianness,
+                    )?;
 
                     let parsing = quote! {
                         byte_index = _bit_sum / 8;
-                        end_byte_index = byte_index + #field_size;
-                        _bit_sum += 8 * #field_size;
-                        let #field_name = if bytes[byte_index..end_byte_index] == [0_u8; #field_size] {
-                            None
-                        } else {
-                            Some(<#inner_tp>::#from_bytes_method({
-                                let slice = &bytes[byte_index..end_byte_index];
-                                let mut arr = [0; #field_size];
-                                arr.copy_from_slice(slice);
-                                arr
-                            }))
+                        end_byte_index = byte_index + #total_size;
+                        if end_byte_index > bytes.len() {
+                            return Err(::bebytes::BeBytesError::InsufficientData {
+                                expected: end_byte_index,
+                                actual: bytes.len(),
+                            });
+                        }
+                        let #field_name = match bytes[byte_index] {
+                            0x00 => None,
+                            0x01 => {
+                                let value_start = byte_index + 1;
+                                #value_parsing
+                            }
+                            tag => return Err(::bebytes::BeBytesError::InvalidDiscriminant {
+                                value: tag,
+                                type_name: "Option",
+                            }),
                         };
+                        _bit_sum += 8 * #total_size;
                     };
 
+                    let value_writing =
+                        create_option_inner_writing(inner_tp, processing_ctx.endianness);
+
                     let writing = quote! {
-                        let bytes_data = &#field_name.unwrap_or(0).#to_bytes_method();
-                        bytes.reserve(bytes_data.len());
-                        bytes.extend_from_slice(bytes_data);
-                        _bit_sum += bytes_data.len() * 8;
+                        match #field_name {
+                            None => {
+                                bytes.reserve(#total_size);
+                                ::bebytes::BufMut::put_u8(bytes, 0x00);
+                                bytes.extend_from_slice(&[0u8; #field_size]);
+                            }
+                            Some(inner_val) => {
+                                bytes.reserve(#total_size);
+                                ::bebytes::BufMut::put_u8(bytes, 0x01);
+                                #value_writing
+                            }
+                        }
+                        _bit_sum += #total_size * 8;
                     };
 
                     let direct_writing =
                         crate::functional::pure_helpers::create_option_primitive_direct_writing(
                             field_name,
                             &inner_type,
+                            field_size,
                             processing_ctx.endianness,
-                        )?;
+                        );
+
                     return Ok(crate::functional::FieldProcessResult::new(
                         quote! {},
                         parsing,


### PR DESCRIPTION
## Summary
- Added support for Option<[u8; N]> arrays
- Fixed Option field handling with tagged format for None/Some(0) disambiguation
- Fixed Option support for f32, f64, bool, char primitives

## Changes
- Tagged wire format: [0x00, zeros...] for None, [0x01, value...] for Some
- Added process_option_array helper for Option<[u8; N]>
- Added helper functions for primitive parsing and direct buffer writing
- New option_types.rs test file