### PR TITLE
fix unqualified Vec paths in generated code for no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.2] - 2025-01-17
+
+### Fixed
+
+- **no_std compatibility**: Use fully qualified `::bebytes::Vec` paths in all generated code
+  - Fixed 4 return type declarations in `lib.rs` (`to_be_bytes`, `to_le_bytes` for structs and enums)
+  - Fixed 10 `Vec::new()` and `Vec::from()` calls in `structs.rs` for vector parsing/writing
+  - Prevents compilation failures in no_std environments where `Vec` is not in prelude
+
+### Changed
+
+- **no_std test improvements**: Tests now import `Vec` from `bebytes` instead of `alloc`
+  - Added 4 new tests covering all Vec codegen paths (FromField, unbounded, marker fields)
+  - Tests will now catch any future regressions in qualified path usage
+
 ## [3.0.0] - 2025-12-21
 
 ### Breaking Changes

--- a/bebytes/Cargo.toml
+++ b/bebytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebytes"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT"
@@ -21,7 +21,7 @@ path = "./bin/performance_benchmark.rs"
 required-features = ["std"]
 
 [dependencies]
-bebytes_derive = { version = "3.0.1" }
+bebytes_derive = { version = "3.0.2" }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/bebytes/tests/no_std.rs
+++ b/bebytes/tests/no_std.rs
@@ -4,8 +4,7 @@
 extern crate alloc;
 
 use alloc::vec;
-use alloc::vec::Vec;
-use bebytes::{BeBytes, BeBytesError};
+use bebytes::{BeBytes, BeBytesError, Vec};
 
 #[derive(BeBytes, Debug, PartialEq)]
 struct SimpleStruct {

--- a/bebytes/tests/no_std.rs
+++ b/bebytes/tests/no_std.rs
@@ -175,3 +175,80 @@ fn test_error_formatting_no_std() {
     let formatted = format!("{}", err);
     assert_eq!(formatted, "Invalid discriminant 42 for type TestEnum");
 }
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct VectorFromField {
+    len: u8,
+    #[FromField(len)]
+    data: Vec<u8>,
+}
+
+#[test]
+fn test_vector_from_field_no_std() {
+    let original = VectorFromField {
+        len: 3,
+        data: vec![0x11, 0x22, 0x33],
+    };
+
+    let bytes = original.to_be_bytes();
+    let (decoded, _) = VectorFromField::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct UnboundedVector {
+    header: u16,
+    data: Vec<u8>,
+}
+
+#[test]
+fn test_unbounded_vector_no_std() {
+    let original = UnboundedVector {
+        header: 0xABCD,
+        data: vec![1, 2, 3, 4, 5],
+    };
+
+    let bytes = original.to_be_bytes();
+    let (decoded, _) = UnboundedVector::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct MarkerStruct {
+    #[UntilMarker(0xFF)]
+    data: Vec<u8>,
+    footer: u8,
+}
+
+#[test]
+fn test_marker_field_no_std() {
+    let original = MarkerStruct {
+        data: vec![0x11, 0x22, 0x33],
+        footer: 0xAA,
+    };
+
+    let bytes = original.to_be_bytes();
+    assert_eq!(bytes, vec![0x11, 0x22, 0x33, 0xFF, 0xAA]);
+
+    let (decoded, _) = MarkerStruct::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[derive(BeBytes, Debug, PartialEq)]
+struct MarkerLastField {
+    header: u8,
+    #[UntilMarker(0xFF)]
+    data: Vec<u8>,
+}
+
+#[test]
+fn test_marker_last_field_no_std() {
+    let original = MarkerLastField {
+        header: 0x42,
+        data: vec![0xAA, 0xBB],
+    };
+
+    let bytes = original.to_be_bytes();
+    let (decoded, _) = MarkerLastField::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded, original);
+}

--- a/bebytes_derive/Cargo.toml
+++ b/bebytes_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bebytes_derive"
 description = "A macro to generate/parse binary representation of messages with custom bit fields"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 publish = true

--- a/bebytes_derive/src/lib.rs
+++ b/bebytes_derive/src/lib.rs
@@ -419,7 +419,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                         }
 
                         #[inline]
-                        fn to_be_bytes(&self) -> Vec<u8> {
+                        fn to_be_bytes(&self) -> ::bebytes::Vec<u8> {
                             let capacity = Self::field_size();
                             let mut buf = ::bebytes::BytesMut::with_capacity(capacity);
                             let mut _bit_sum = 0;
@@ -456,7 +456,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                         }
 
                         #[inline]
-                        fn to_le_bytes(&self) -> Vec<u8> {
+                        fn to_le_bytes(&self) -> ::bebytes::Vec<u8> {
                             let capacity = Self::field_size();
                             let mut buf = ::bebytes::BytesMut::with_capacity(capacity);
                             let mut _bit_sum = 0;
@@ -672,7 +672,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                     }
 
                     #[inline]
-                    fn to_be_bytes(&self) -> Vec<u8> {
+                    fn to_be_bytes(&self) -> ::bebytes::Vec<u8> {
                         let mut buf = ::bebytes::BytesMut::with_capacity(#byte_size_lit);
                         let val = match self {
                             #(#to_be_bytes_arms)*
@@ -697,7 +697,7 @@ pub fn derive_be_bytes(input: TokenStream) -> TokenStream {
                     }
 
                     #[inline]
-                    fn to_le_bytes(&self) -> Vec<u8> {
+                    fn to_le_bytes(&self) -> ::bebytes::Vec<u8> {
                         let mut buf = ::bebytes::BytesMut::with_capacity(#byte_size_lit);
                         let val = match self {
                             #(#to_le_bytes_arms)*

--- a/bebytes_derive/src/structs.rs
+++ b/bebytes_derive/src/structs.rs
@@ -9,7 +9,7 @@ fn convert_to_direct_writing(writing_code: &proc_macro2::TokenStream) -> proc_ma
     // This avoids variable name conflicts while maintaining correctness
     quote! {
         {
-            let mut field_bytes = Vec::new();
+            let mut field_bytes = ::bebytes::Vec::new();
             {
                 let bytes = &mut field_bytes; // Create alias to avoid conflicts with 'bytes' crate
                 #writing_code
@@ -884,7 +884,7 @@ fn generate_primitive_vector_tokens(
                     if end_index > bytes.len() {
                         panic!("Not enough bytes to parse a vector of size {} (field: {}, byte_index: {}, bytes.len(): {})", vec_size, stringify!(#field_name), byte_index, bytes.len());
                     }
-                    let #field_name = Vec::from(&bytes[byte_index..end_index]);
+                    let #field_name = ::bebytes::Vec::from(&bytes[byte_index..end_index]);
                     _bit_sum += vec_size * 8;
                 },
                 quote! {
@@ -900,7 +900,7 @@ fn generate_primitive_vector_tokens(
                 let vec_size = #s as usize;
                 byte_index = _bit_sum / 8;
                 let end_index = byte_index + vec_size;
-                let #field_name = Vec::from(&bytes[byte_index..end_index]);
+                let #field_name = ::bebytes::Vec::from(&bytes[byte_index..end_index]);
                 _bit_sum += #s * 8;
             },
             quote! {
@@ -920,7 +920,7 @@ fn generate_primitive_vector_tokens(
                 quote! { bit_sum = 4096 * 8; },
                 quote! {
                     byte_index = _bit_sum / 8;
-                    let #field_name = Vec::from(&bytes[byte_index..]);
+                    let #field_name = ::bebytes::Vec::from(&bytes[byte_index..]);
                     _bit_sum += #field_name.len() * 8;
                 },
                 quote! {
@@ -1046,7 +1046,7 @@ fn process_vector_functional(
             let to_bytes_method = utils::get_to_bytes_method(processing_ctx.endianness);
 
             let parsing_init = quote! {
-                let mut #field_name = Vec::new();
+                let mut #field_name = ::bebytes::Vec::new();
             };
 
             let parsing_loop = generate_custom_vector_parsing(
@@ -1776,7 +1776,7 @@ fn process_until_marker_functional(
         // Last field: consume all remaining bytes if marker not found
         quote! {
             byte_index = _bit_sum / 8;
-            let mut #field_name = Vec::new();
+            let mut #field_name = ::bebytes::Vec::new();
 
             // Read bytes until we find the marker
             while byte_index < bytes.len() && bytes[byte_index] != #marker {
@@ -1795,7 +1795,7 @@ fn process_until_marker_functional(
         // Not last field: error if marker not found
         quote! {
             byte_index = _bit_sum / 8;
-            let mut #field_name = Vec::new();
+            let mut #field_name = ::bebytes::Vec::new();
             let mut marker_found = false;
 
             // Read bytes until we find the marker
@@ -1872,7 +1872,7 @@ fn process_after_marker_functional(
             remaining
         } else {
             // No marker found, field is empty
-            Vec::new()
+            ::bebytes::Vec::new()
         };
     };
 
@@ -1931,11 +1931,11 @@ fn process_vec_of_vecs_with_marker_functional(
 
     let parsing = quote! {
         byte_index = _bit_sum / 8;
-        let mut #field_name = Vec::new();
+        let mut #field_name = ::bebytes::Vec::new();
 
         // Read exactly the specified number of segments
         for segment_idx in 0..#size_expr {
-            let mut current_section = Vec::new();
+            let mut current_section = ::bebytes::Vec::new();
             let mut marker_found = false;
 
             // Read until marker for this segment


### PR DESCRIPTION
## Summary
- Use `::bebytes::Vec` instead of unqualified `Vec` in all generated code
- Fixes 14 locations across `lib.rs` and `structs.rs` where `Vec::new()`, `Vec::from()`, or return types used unqualified paths
- Update `no_std.rs` test to import `Vec` from `bebytes` instead of `alloc`, ensuring future regressions are caught

## Test plan
- [x] `cargo test` passes
- [x] `cargo test --no-default-features -p bebytes no_std` passes
- [x] `cargo clippy` clean